### PR TITLE
Fix doubled callback

### DIFF
--- a/src/utils/blockchainHelpers.js
+++ b/src/utils/blockchainHelpers.js
@@ -213,10 +213,7 @@ export function deployContract(i, web3, abi, bin, params, state, cb) {
           }
           else if (contract.transactionHash) {
             checkTxMined(web3, contract.transactionHash, function txMinedCallback(receipt) {
-              if (receipt) {
-                if (receipt.blockNumber)
-                  return cb(null, receipt.contractAddress);
-              } else {
+              if (!receipt) {
                 setTimeout(checkTxMined(web3, contract.transactionHash, txMinedCallback), 1000);
               }
             })


### PR DESCRIPTION
Found that an each contract creation callback is invoked 2 times due the logic of `web3.js` library:
- first time without `contract.address` assigned, right after transaction was sent
- second time with `contract.address` assigned, after a contract was created

Suggest to invoke `deployed` callback after contract creation only, so we'll have an access to it's address.