### PR TITLE
ABI encoded parameters without 0x

### DIFF
--- a/src/utils/microservices.js
+++ b/src/utils/microservices.js
@@ -28,5 +28,7 @@ function getABIencoded(web3, types, vals, cb) {
 	console.log(vals);
 
 	let encoded = web3.eth.abi.encodeParameters(types, vals);
-	cb(encoded.toString("hex"));
+	let outputRaw = encoded.toString("hex")
+	let output = outputRaw.indexOf("0x") > -1?outputRaw.substr(2):outputRaw
+	cb(output);
 }


### PR DESCRIPTION
Relates to https://github.com/oraclesorg/ico-wizard/issues/302