### PR TITLE
(Fix) No error message on invest form submit

### DIFF
--- a/src/components/invest/index.js
+++ b/src/components/invest/index.js
@@ -11,13 +11,13 @@ import { defaultState, GAS_PRICE } from '../../utils/constants'
 export class Invest extends React.Component {
   constructor(props) {
       super(props);
-      this.pristineTokenInput = true;
       window.scrollTo(0, 0);
       if (this.tokensToInvestOnChange.bind) this.tokensToInvestOnChange = this.tokensToInvestOnChange.bind(this);
       if (this.investToTokens.bind) this.investToTokens = this.investToTokens.bind(this);
       var state = defaultState;
       state.seconds = 0;
       state.loading = true;
+      state.pristineTokenInput = true;
       this.state = state;
   }
 
@@ -115,7 +115,7 @@ export class Invest extends React.Component {
     event.preventDefault();
 
     if (!this.isValidToken(this.state.tokensToInvest)) {
-      this.pristineTokenInput = false;
+      this.setState({ pristineTokenInput: false });
       return;
     }
 
@@ -231,7 +231,7 @@ export class Invest extends React.Component {
   }
 
   tokensToInvestOnChange(event) {
-    this.pristineTokenInput = false;
+    this.setState({ pristineTokenInput: false });
 
     let state = this.state;
     state["tokensToInvest"] = event.target.value;
@@ -296,7 +296,7 @@ export class Invest extends React.Component {
     const totalSupply = (this.state.contractType === this.state.contractTypes.whitelistwithcap)?tierCap:standardCrowdsaleSupply;
 
     let invalidTokenDescription = null;
-    if (!this.pristineTokenInput && !this.isValidToken(this.state.tokensToInvest)) {
+    if (!this.state.pristineTokenInput && !this.isValidToken(this.state.tokensToInvest)) {
       invalidTokenDescription = <p className="error">Number of tokens to buy should be positive</p>;
     }
 


### PR DESCRIPTION
Closes #273 (https://github.com/oraclesorg/ico-wizard/issues/273#issuecomment-341449487)

- Displays error message if the user tries to Invest without entering a valid token amount.
- Moved input's pristine flag, into the Component's state.

![error_message-appears_on_pristine_submit](https://user-images.githubusercontent.com/3315606/32337130-ecaef726-bfcf-11e7-8a10-d90eda991489.gif)


