### PR TITLE
(Feature) Toaster on contract download

### DIFF
--- a/src/components/stepFour/constants.js
+++ b/src/components/stepFour/constants.js
@@ -1,0 +1,1 @@
+export const alertOptions = { time: 10000, position: 'top right' }

--- a/src/components/stepFour/constants.js
+++ b/src/components/stepFour/constants.js
@@ -1,1 +1,2 @@
 export const alertOptions = { time: 10000, position: 'top right' }
+export const fileDownloadedToasterMsg = "A file with contracts and metadata downloaded on your computer"

--- a/src/components/stepFour/index.js
+++ b/src/components/stepFour/index.js
@@ -15,7 +15,7 @@ import { Loader } from '../Common/Loader'
 import { NAVIGATION_STEPS, TRUNC_TO_DECIMALS } from '../../utils/constants'
 import { copy } from '../../utils/copy';
 import AlertContainer from 'react-alert'
-import { alertOptions } from './constants'
+import { alertOptions, fileDownloadedToasterMsg } from './constants'
 const { PUBLISH } = NAVIGATION_STEPS
 
 export class stepFour extends stepTwo {
@@ -499,7 +499,7 @@ export class stepFour extends stepTwo {
                           if (err) return this.hideLoader();
                           this.hideLoader();
                           this.downloadCrowdsaleInfo();
-                          this.showToaster({ message: 'A file with contracts and metadata downloaded on your computer' })   
+                          this.showToaster({ message: fileDownloadedToasterMsg })   
                           //this.goToCrowdsalePage();
                         });
                       });

--- a/src/components/stepFour/index.js
+++ b/src/components/stepFour/index.js
@@ -15,6 +15,7 @@ import { Loader } from '../Common/Loader'
 import { NAVIGATION_STEPS, TRUNC_TO_DECIMALS } from '../../utils/constants'
 import { copy } from '../../utils/copy';
 import AlertContainer from 'react-alert'
+import { alertOptions } from './constants'
 const { PUBLISH } = NAVIGATION_STEPS
 
 export class stepFour extends stepTwo {
@@ -22,7 +23,6 @@ export class stepFour extends stepTwo {
     super(props);
     let oldState = getOldState(props, defaultState)
     this.state = Object.assign({}, oldState)
-    this.alertOptions = { time: 10000, position: 'top right' }
     console.log('oldState oldState oldState', oldState)
   }
 
@@ -499,7 +499,7 @@ export class stepFour extends stepTwo {
                           if (err) return this.hideLoader();
                           this.hideLoader();
                           this.downloadCrowdsaleInfo();
-                          this.showToaster({ message: 'A file with contracts and metadata downloaded on your computer' })
+                          this.showToaster({ message: 'A file with contracts and metadata downloaded on your computer' })   
                           //this.goToCrowdsalePage();
                         });
                       });
@@ -778,7 +778,7 @@ export class stepFour extends stepTwo {
           <a onClick={this.goToCrowdsalePage} className="button button_fill">Continue</a>
         </div>
         <Loader show={this.state.loading}></Loader>
-        <AlertContainer ref={a => this.msg = a} {...this.alertOptions} />
+        <AlertContainer ref={a => this.msg = a} {...alertOptions} />
       </section>
     )}
 }

--- a/src/components/stepFour/index.js
+++ b/src/components/stepFour/index.js
@@ -14,6 +14,7 @@ import { DisplayTextArea } from '../Common/DisplayTextArea'
 import { Loader } from '../Common/Loader'
 import { NAVIGATION_STEPS, TRUNC_TO_DECIMALS } from '../../utils/constants'
 import { copy } from '../../utils/copy';
+import AlertContainer from 'react-alert'
 const { PUBLISH } = NAVIGATION_STEPS
 
 export class stepFour extends stepTwo {
@@ -21,6 +22,7 @@ export class stepFour extends stepTwo {
     super(props);
     let oldState = getOldState(props, defaultState)
     this.state = Object.assign({}, oldState)
+    this.alertOptions = { time: 10000, position: 'top right' }
     console.log('oldState oldState oldState', oldState)
   }
 
@@ -476,7 +478,6 @@ export class stepFour extends stepTwo {
       let web3 = this.state.web3;
       let contracts = this.state.contracts;
       console.log(contracts);
-      this.downloadCrowdsaleInfo();
 
       this.setState(() => {
         setLastCrowdsaleRecursive(0, web3, contracts.pricingStrategy.abi, contracts.pricingStrategy.addr, contracts.crowdsale.addr.slice(-1)[0], 142982, (err) => {
@@ -497,6 +498,8 @@ export class stepFour extends stepTwo {
                         transferOwnership(web3, this.state.contracts.token.abi, contracts.token.addr, this.state.crowdsale[0].walletAddress, 46699, (err) => {
                           if (err) return this.hideLoader();
                           this.hideLoader();
+                          this.downloadCrowdsaleInfo();
+                          this.showToaster({ message: 'A file with contracts and metadata downloaded on your computer' })
                           //this.goToCrowdsalePage();
                         });
                       });
@@ -532,6 +535,14 @@ export class stepFour extends stepTwo {
     //url += `&contractType=` + this.state.contractType
     let newHistory = isValidContract ? url : crowdsalePage
     this.props.history.push(newHistory);
+  }
+
+  showToaster = ({type = 'info', message = ''}) => {
+    if (!message) {
+      return
+    }
+
+    this.msg[type](message);
   }
 
   render() {
@@ -767,6 +778,7 @@ export class stepFour extends stepTwo {
           <a onClick={this.goToCrowdsalePage} className="button button_fill">Continue</a>
         </div>
         <Loader show={this.state.loading}></Loader>
+        <AlertContainer ref={a => this.msg = a} {...this.alertOptions} />
       </section>
     )}
 }


### PR DESCRIPTION
Closes #270 

- Added a toaster informing the user that the contract was properly downloaded on the PC.
- Moved the Contract Download option after the last transaction, to avoid "Loading" overlay and "Toaster" overlapping.

![alert-on-contract-download](https://user-images.githubusercontent.com/3315606/32392655-407ccd66-c0b5-11e7-8935-1f2f6ba77431.gif)
