### PR TITLE
(Feature) Support for byzantium tx success/fail statuses

### DIFF
--- a/src/components/invest/index.js
+++ b/src/components/invest/index.js
@@ -200,13 +200,13 @@ export class Invest extends React.Component {
     };
     console.log(opts);
 
-    sendTXToContract(web3, crowdsaleContract.methods.buy().send(opts), err => {
+    sendTXToContract(crowdsaleContract.methods.buy().send(opts), err => {
       this.setState({ loading: false });
 
       if (!err) {
-        successfulInvestmentAlert(this.state.tokensToInvest);
+        successfulInvestmentAlert(this.state.tokensToInvest)
       } else {
-        toast.showToaster({ type: TOAST.TYPE.ERROR, message: TOAST.MESSAGE.USER_REJECTED_TRANSACTION })
+        toast.showToaster({ type: TOAST.TYPE.ERROR, message: TOAST.MESSAGE.TRANSACTION_FAILED })
       }
     });
   }

--- a/src/components/stepFour/utils.js
+++ b/src/components/stepFour/utils.js
@@ -21,7 +21,7 @@ function setLastCrowdsale(web3, abi, addr, lastCrowdsale, gasLimit, cb) {
     if (!pricingStrategyContract) return noContractAlert();
 
     let method = pricingStrategyContract.methods.setLastCrowdsale(lastCrowdsale).send({gasLimit: gasLimit, gasPrice: GAS_PRICE})
-    sendTXToContract(web3, method, cb);
+    sendTXToContract(method, cb);
   });
 }
 
@@ -37,7 +37,7 @@ function setMintAgent(web3, abi, addr, acc, gasLimit, cb) {
     if (!tokenContract) return noContractAlert();
 
     let method = tokenContract.methods.setMintAgent(acc, true).send({gasLimit: gasLimit, gasPrice: GAS_PRICE})
-    sendTXToContract(web3, method, cb);
+    sendTXToContract(method, cb);
   });
 }
 
@@ -113,7 +113,7 @@ function addWhiteList(round, web3, crowdsale, token, abi, addr, cb) {
     console.log(maxCaps);
 
     let method = crowdsaleContract.methods.setEarlyParicipantsWhitelist(addrs, statuses, minCaps, maxCaps).send({gasPrice: GAS_PRICE})
-    sendTXToContract(web3, method, cb)
+    sendTXToContract(method, cb)
   });
 }
 
@@ -131,7 +131,7 @@ function updateJoinedCrowdsales(web3, abi, addr, joinedCntrctAddrs, gasLimit, cb
     console.log(joinedCntrctAddrs);
 
     let method = crowdsaleContract.methods.updateJoinedCrowdsalesMultiple(joinedCntrctAddrs).send({gasLimit: gasLimit, gasPrice: GAS_PRICE})
-    sendTXToContract(web3, method, cb);
+    sendTXToContract(method, cb);
   });
 }
 
@@ -146,7 +146,7 @@ function setFinalizeAgent(web3, abi, addr, finalizeAgentAddr, gasLimit, cb) {
     if (!crowdsaleContract) return noContractAlert();
 
     let method = crowdsaleContract.methods.setFinalizeAgent(finalizeAgentAddr).send({gasLimit: gasLimit, gasPrice: GAS_PRICE})
-    sendTXToContract(web3, method, cb);
+    sendTXToContract(method, cb);
   });
 }
 
@@ -161,7 +161,7 @@ function setReleaseAgent(web3, abi, addr, finalizeAgentAddr, gasLimit, cb) {
     if (!tokenContract) return noContractAlert();
 
     let method = tokenContract.methods.setReleaseAgent(finalizeAgentAddr).send({gasLimit: gasLimit, gasPrice: GAS_PRICE})
-    sendTXToContract(web3, method, cb);
+    sendTXToContract(method, cb);
   });
 }
 
@@ -222,7 +222,7 @@ export function setReservedTokensListMultiple(web3, abi, addr, token, cb) {
     console.log("inPercentageDecimals: " + inPercentageDecimals)
 
     let method = tokenContract.methods.setReservedTokensListMultiple(addrs, inTokens, inPercentageUnit, inPercentageDecimals).send({gasPrice: GAS_PRICE})
-    sendTXToContract(web3, method, cb)
+    sendTXToContract(method, cb)
   });
 }
 
@@ -237,7 +237,7 @@ export function transferOwnership(web3, abi, addr, finalizeAgentAddr, gasLimit, 
     if (!tokenContract) return noContractAlert();
 
     let method = tokenContract.methods.transferOwnership(finalizeAgentAddr).send({gasLimit: gasLimit, gasPrice: GAS_PRICE})
-    sendTXToContract(web3, method, cb);
+    sendTXToContract(method, cb);
   });
 }
 

--- a/src/utils/blockchainHelpers.js
+++ b/src/utils/blockchainHelpers.js
@@ -213,49 +213,17 @@ export function deployContract(i, web3, abi, bin, params, state, cb) {
   });
 }
 
-export function sendTXToContract(web3, method, cb) {
-  let isMined = false;
+export function sendTXToContract(method, cb) {
   method
-  .on('error', function(error) {
-    console.log(error);
-    return cb(error);
-  })
-  .on('transactionHash', function(transactionHash){
-    console.log("contract method transaction: " + transactionHash);
-
-    checkTxMined(web3, transactionHash, function txMinedCallback(receipt) {
-      if (isMined) return;
-
-      if (receipt) {
-        if (receipt.blockNumber) {
-          console.log("Sending tx to contract is mined from polling of tx receipt");
-          isMined = true;
-          console.log(receipt) // instance with the new contract address
-          return cb();
-        } else {
-          console.log("Still mining... Polling of transaction once more");
-          setTimeout(function() {
-            checkTxMined(web3, transactionHash, txMinedCallback)
-          }, 5000);
-        }
-      } else {
-        console.log("Still mining... Polling of transaction once more");
-        setTimeout(function() {
-          checkTxMined(web3, transactionHash, txMinedCallback)
-        }, 5000);
+    .on('receipt', receipt => {
+      if (0 !== receipt.status) {
+        return cb()
       }
+      return cb({ message: 0 })
     })
-  })
-  .on('confirmation', function(confirmationNumber, receipt){
-  })
-  .then(function(result){
-    if (!isMined) {
-      console.log("Sending tx to contract is mined from Promise");
-      isMined = true;
-      console.log(result) // instance with the new contract address
-      cb();
-    }
-  });
+    .on('error', error => {
+      return cb(error)
+    })
 }
 
 export function checkTxMined(web3, txhash, cb) {

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,11 +1,11 @@
-export const defaultState = { 
-	contracts: { 
-		token: {}, 
+export const defaultState = {
+	contracts: {
+		token: {},
 		crowdsale: {addr:[], abiConstructor:[]},
 		pricingStrategy: {addr:[], abiConstructor:[]},
 		nullFinalizeAgent: {addr:[], abiConstructor:[]},
 		finalizeAgent: {addr:[], abiConstructor:[]}
-	}, 
+	},
 	token: {
 		name: '',
 		ticker: '',
@@ -19,8 +19,8 @@ export const defaultState = {
 		endTime: '',
 		walletAddress: '',
 		supply: '',
-		whitelist: [], 
-		whiteListElements: [], 
+		whitelist: [],
+		whiteListElements: [],
 		whiteListInput: {}
 	}],
 	pricingStrategy: [{rate: ''}],
@@ -320,9 +320,10 @@ export const TOAST = {
 		SUCCESS: 'warning'
 	},
 	MESSAGE: {
-		USER_REJECTED_TRANSACTION: 'User Rejected Transaction',
+		TRANSACTION_FAILED: 'Transaction has failed, please retry',
 		CONTRACT_DOWNLOAD_FAILED: 'Contract Download failed',
-		CONTRACT_DOWNLOAD_SUCCESS: 'A file with contracts and metadata downloaded on your computer'},
+		CONTRACT_DOWNLOAD_SUCCESS: 'A file with contracts and metadata downloaded on your computer'
+	},
 	DEFAULT_OPTIONS: {
 		position: 'top right',
 		offset: '80px 14',


### PR DESCRIPTION
This closes issue #292 

- For the invest page, toaster error message will always be the same: 'Transaction has failed, please retry' (if the user rejects a transaction, if a transaction ran out of gas or any other exception)
- It can be tested locally with testrpc ^6.0.0, it supports Byzantium features
- To test properly, block auto-mining should be disabled. That is: `testrpc --blocktime 1`, if not... no event will be triggered for on-chain errors.
