### PR TITLE
(Chore) Add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -12,6 +12,12 @@ If you are reporting a problem with ICO Wizard, please include the following inf
 
 *Your answer*
 
+### Do you see errors in the dev console? If yes, please include a screenshot
+
+(To open the dev console in Google Chrome, press F12, or go to `View -> Developer -> Developer Tools`, and open the Console tab)
+
+*Your answer*
+
 ---
 
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,17 @@
+If you are reporting a problem with ICO Wizard, please include the following information:
+
+### Which network did you use? (Mainnet, Kovan, Rinkeby, etc.)
+
+*Your answer*
+
+### If you were able to create it, what is the URL of your crowdsale?
+
+*Your answer*
+
+### Do you have screenshots showing the problem?
+
+*Your answer*
+
+---
+
+


### PR DESCRIPTION
There have been several reported issues that don't provide some basic information. This adds a template so that people opening bugs can know which is the minimal data that they should include with the report.