### PR TITLE
(Fix) Time validations step3

### DIFF
--- a/src/components/Common/CrowdsaleBlock.js
+++ b/src/components/Common/CrowdsaleBlock.js
@@ -79,7 +79,7 @@ export class CrowdsaleBlock extends React.Component {
             title={START_TIME}
             value={tierStore.tiers[num].startTime}
             valid={tierStore.validTiers[num].startTime}
-            errorMessage={VALIDATION_MESSAGES.START_TIME}
+            errorMessage={VALIDATION_MESSAGES.MULTIPLE_TIERS_START_TIME}
             onChange={(e) => this.updateTierStore(e, 'startTime')}
             description={`Date and time when the tier starts. Can't be in the past from the current moment.`}
           />

--- a/src/components/stepThree/index.js
+++ b/src/components/stepThree/index.js
@@ -114,8 +114,29 @@ export class stepThree extends React.Component{
   renderLink () {
     return <div>
       <div onClick={() => this.addCrowdsale()} className="button button_fill_secondary"> Add Tier</div>
-      <Link to={{ pathname: '/4', query: { state: this.state, changeState: this.changeState } }} className="button button_fill">Continue</Link>
+      <Link to={{ pathname: '/4', query: { state: this.state, changeState: this.changeState } }}
+            onClick={e => this.beforeNavigate(e)}
+            className="button button_fill"
+      >Continue</Link>
     </div>
+  }
+
+  beforeNavigate = e => {
+    e.preventDefault()
+    e.stopPropagation()
+
+    const { tierStore } = this.props
+
+    for (let index = 0; index < tierStore.tiers.length; index++) {
+      tierStore.validateTiers('endTime', index)
+      tierStore.validateTiers('startTime', index)
+    }
+
+    if (tierStore.areTiersValid) {
+      this.props.history.push('/4')
+    } else {
+      this.showErrorMessages(e)
+    }
   }
 
   renderStandardLinkComponent () {

--- a/src/components/stepThree/index.js
+++ b/src/components/stepThree/index.js
@@ -150,17 +150,6 @@ export class stepThree extends React.Component{
     </div>
   }
 
-  renderLinkComponent () {
-    if(this.props.tierStore.areTiersValid){
-      return this.renderLink()
-    }
-
-    return <div>
-      <div onClick={() => this.addCrowdsale()} className="button button_fill_secondary"> Add Tier</div>
-      <div onClick={this.showErrorMessages.bind(this)} className="button button_fill"> Continue</div>
-    </div>
-  }
-
     componentDidMount () {
       const { tierStore, web3Store } = this.props
       const { curAddress } = web3Store
@@ -377,7 +366,7 @@ export class stepThree extends React.Component{
           </div>
           <div>{crowdsaleBlockListStore.blockList}</div>
           <div className="button-container">
-            {this.renderLinkComponent()}
+            {this.renderLink()}
           </div>
         </section>
       )

--- a/src/stores/TierStore.js
+++ b/src/stores/TierStore.js
@@ -1,6 +1,6 @@
 import { observable, action, computed } from 'mobx';
 import { VALIDATION_TYPES, defaultTiers } from '../utils/constants'
-import { validateName, validateTime, validateSupply, validateRate, validateAddress, validateLaterTime } from '../utils/utils'
+import { validateName, validateTime, validateSupply, validateRate, validateAddress, validateLaterTime, validateLaterOrEqualTime } from '../utils/utils'
 const { VALID, INVALID, EMPTY } = VALIDATION_TYPES
 class TierStore {
 
@@ -67,6 +67,10 @@ class TierStore {
         this.validTiers[index][property] = validateRate(this.tiers[index][property]) ? VALID : INVALID
         return
       case 'startTime':
+        if (index > 0) {
+          this.validTiers[index][property] = validateLaterOrEqualTime(this.tiers[index][property], this.tiers[index - 1].endTime) ? VALID : INVALID
+          return
+        }
         this.validTiers[index][property] = validateTime(this.tiers[index][property]) ? VALID: INVALID
         return
       case 'endTime':

--- a/src/stores/TierStore.js
+++ b/src/stores/TierStore.js
@@ -1,6 +1,6 @@
 import { observable, action, computed } from 'mobx';
 import { VALIDATION_TYPES, defaultTiers } from '../utils/constants'
-import { validateName, validateTime, validateSupply, validateRate, validateAddress } from '../utils/utils'
+import { validateName, validateTime, validateSupply, validateRate, validateAddress, validateLaterTime } from '../utils/utils'
 const { VALID, INVALID, EMPTY } = VALIDATION_TYPES
 class TierStore {
 
@@ -67,8 +67,10 @@ class TierStore {
         this.validTiers[index][property] = validateRate(this.tiers[index][property]) ? VALID : INVALID
         return
       case 'startTime':
-      case 'endTime':
         this.validTiers[index][property] = validateTime(this.tiers[index][property]) ? VALID: INVALID
+        return
+      case 'endTime':
+        this.validTiers[index][property] = validateLaterTime(this.tiers[index][property], this.tiers[index].startTime) ? VALID : INVALID
         return
     }
   }

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -89,6 +89,7 @@ export const VALIDATION_MESSAGES = {
   WALLET_ADDRESS: 'Please enter a valid address',
   START_TIME: 'Please enter a valid date later than now',
   END_TIME: 'Please enter a valid date later than start time',
+  MULTIPLE_TIERS_START_TIME: 'Please enter a valid date not less than the end time of the previous tier',
   RATE: 'Please enter a valid number greater than 0'
 }
 

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -325,6 +325,8 @@ export const validateTicker = (ticker) => typeof ticker === 'string' && ticker.l
 
 export const validateTime = (time) => getTimeAsNumber(time) > Date.now()
 
+export const validateLaterTime = (laterTime, previousTime) => getTimeAsNumber(laterTime) > getTimeAsNumber(previousTime)
+
 export const validateRate = (rate) => isNaN(Number(rate)) === false && Number(rate) > 0
 
 export const validateAddress = (address) => {

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -327,6 +327,8 @@ export const validateTime = (time) => getTimeAsNumber(time) > Date.now()
 
 export const validateLaterTime = (laterTime, previousTime) => getTimeAsNumber(laterTime) > getTimeAsNumber(previousTime)
 
+export const validateLaterOrEqualTime = (laterTime, previousTime) => getTimeAsNumber(laterTime) >= getTimeAsNumber(previousTime)
+
 export const validateRate = (rate) => isNaN(Number(rate)) === false && Number(rate) > 0
 
 export const validateAddress = (address) => {


### PR DESCRIPTION
Closes #233 

- validation for end time > start time for 2nd tier and further
- validation, that start time of the tier cannot be less than end time of the previous tier
- validation, before continuing checks that the dates are valid (i.e.: start date can be set later than end date, and wasn't validated properly)

![startdate_later-than_enddate](https://user-images.githubusercontent.com/3315606/33576754-af9feb2e-d91f-11e7-875c-4b98d9384d98.gif)
