### PR TITLE
(Refactor) Fix linter errors and warnings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,10 @@
+{
+  "extends": "react-app",
+  "rules": {
+    "indent": ["error", 2, {
+      "SwitchCase": 1
+    }],
+    "no-mixed-spaces-and-tabs": "error",
+    "no-trailing-spaces": "error"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -127,7 +127,8 @@
     "compileCrowdsaleTokenContractWin": "node ./scripts/compileContract.js %npm_package_config_contract_folder%/CrowdsaleWhiteListWithCapToken_flat.sol %npm_package_config_contract_folder% %npm_package_config_extension_path% false %npm_package_config_crowdsale_token_contract_name% CrowdsaleWhiteListWithCapToken",
     "compileCrowdsalePricingStrategyContractWin": "node ./scripts/compileContract.js %npm_package_config_contract_folder%/CrowdsaleWhiteListWithCapPricingStrategy_flat.sol %npm_package_config_contract_folder% %npm_package_config_extension_path% false %npm_package_config_crowdsale_pricing_strategy_contract_name% CrowdsaleWhiteListWithCapPricingStrategy",
     "compileCrowdsaleNullFinalizeAgentContractWin": "node ./scripts/compileContract.js %npm_package_config_contract_folder%/NullFinalizeAgent_flat.sol %npm_package_config_contract_folder% %npm_package_config_extension_path% false %npm_package_config_null_finalize_agent_contract_name% NullFinalizeAgent",
-    "compileCrowdsaleFinalizeAgentContractWin": "node ./scripts/compileContract.js %npm_package_config_contract_folder%/FinalizeAgent_flat.sol %npm_package_config_contract_folder% %npm_package_config_extension_path% false %npm_package_config_finalize_agent_contract_name% FinalizeAgent"
+    "compileCrowdsaleFinalizeAgentContractWin": "node ./scripts/compileContract.js %npm_package_config_contract_folder%/FinalizeAgent_flat.sol %npm_package_config_contract_folder% %npm_package_config_extension_path% false %npm_package_config_finalize_agent_contract_name% FinalizeAgent",
+    "lint": "eslint src"
   },
   "jest": {
     "collectCoverageFrom": [

--- a/src/App.js
+++ b/src/App.js
@@ -10,9 +10,6 @@ import AlertContainer from 'react-alert'
 import { TOAST } from './utils/constants'
 import { toast } from './utils/utils'
 
-const myDiv = () => ( <div> my div</div>)
-
-
 console.log('stepThree', stepThree, 'stepTwo', stepTwo)
 class App extends Component {
   render() {

--- a/src/components/Common/CrowdsaleBlock.js
+++ b/src/components/Common/CrowdsaleBlock.js
@@ -5,8 +5,7 @@ import { defaultCompanyEndDate } from '../../utils/utils'
 import { InputField } from './InputField'
 import { RadioInputField } from './RadioInputField'
 import { inject, observer } from 'mobx-react'
-import { VALIDATION_MESSAGES, VALIDATION_TYPES, TEXT_FIELDS } from '../../utils/constants'
-const { EMPTY, VALID, INVALID } = VALIDATION_TYPES
+import { VALIDATION_MESSAGES, TEXT_FIELDS } from '../../utils/constants'
 const { START_TIME, END_TIME, RATE, SUPPLY, CROWDSALE_SETUP_NAME, ALLOWMODIFYING } = TEXT_FIELDS
 
 @inject('tierStore')

--- a/src/components/Common/Loader.js
+++ b/src/components/Common/Loader.js
@@ -2,7 +2,7 @@ import React from 'react'
 import '../../assets/stylesheets/application.css';
 
 export const Loader = ({show}) => {
-	return <div className={show?"loading-container":"loading-container notdisplayed"}>
+  return <div className={show?"loading-container":"loading-container notdisplayed"}>
     <div className="loading">
       <div className="loading-i"></div>
       <div className="loading-i"></div>

--- a/src/components/Common/RadioInputField.js
+++ b/src/components/Common/RadioInputField.js
@@ -2,26 +2,26 @@ import React from 'react'
 import '../../assets/stylesheets/application.css';
 
 export class RadioInputField extends React.Component {
-	constructor(props) {
-        super(props);
-        this.state = {
-        	"checked1": props.defaultValue===this.props.vals[0]?true:false,
-        	"checked2": props.defaultValue===this.props.vals[0]?false:true
-        }
+  constructor(props) {
+    super(props);
+    this.state = {
+      "checked1": props.defaultValue===this.props.vals[0]?true:false,
+      "checked2": props.defaultValue===this.props.vals[0]?false:true
     }
+  }
 
-    onChange(e) {
-    	console.log(e.target);
-    	this.setState({
-    		"checked1": e.target.value===this.props.vals[0]?true:false,
-    		"checked2": e.target.value===this.props.vals[0]?false:true});
-    	this.props.onChange(e);
-    }
+  onChange(e) {
+    console.log(e.target);
+    this.setState({
+      "checked1": e.target.value===this.props.vals[0]?true:false,
+      "checked2": e.target.value===this.props.vals[0]?false:true});
+    this.props.onChange(e);
+  }
 
-	render() {
-		return (<div className={this.props.side}>
-		<label className="label">{this.props.title}</label>
-		<div className="radios-inline">
+  render() {
+    return (<div className={this.props.side}>
+    <label className="label">{this.props.title}</label>
+    <div className="radios-inline">
             <label className="radio-inline">
               <input
                 type="radio"
@@ -43,9 +43,9 @@ export class RadioInputField extends React.Component {
               <span className="title">{this.props.items[1]}</span>
             </label>
           </div>
-		<p className="description">
-			{this.props.description}
-		</p>
-		</div>)
-	}
+    <p className="description">
+      {this.props.description}
+    </p>
+    </div>)
+  }
 }

--- a/src/components/Common/config.js
+++ b/src/components/Common/config.js
@@ -1,10 +1,10 @@
-const networks = {
-	mainnet: 1,
-	morden: 2,
-	ropsten: 3,
-	rinkeby: 4,
-	kovan: 42,
-	oraclesTest: 12648430
-}
+// const networks = {
+// 	mainnet: 1,
+// 	morden: 2,
+// 	ropsten: 3,
+// 	rinkeby: 4,
+// 	kovan: 42,
+// 	oraclesTest: 12648430
+// }
 
 export const ICOConfig = {};

--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -3,16 +3,16 @@ import '../../assets/stylesheets/application.css';
 import { Link } from 'react-router-dom'
 
 export const Footer = () => (
-	<footer className="footer">
-		<div className="container">
-			<p className="rights">2017 Oracles Network. All rights reserved.</p>
+  <footer className="footer">
+    <div className="container">
+      <p className="rights">2017 Oracles Network. All rights reserved.</p>
       <Link className="logo" to='/'></Link>
-			<div className="socials">
-			  <a href="https://twitter.com/oraclesorg" className="social social_twitter"></a>
-        <a href="https://www.oracles.org" className="social social_oracles"></a>
-        <a href="https://t.me/oraclesnetwork" className="social social_telegram"></a>
-        <a href="https://github.com/oraclesorg/" className="social social_github"></a>
-			</div>
-		</div>
-	</footer>
+      <div className="socials">
+        <a href="https://twitter.com/oraclesorg" className="social social_twitter">Twitter</a>
+        <a href="https://www.oracles.org" className="social social_oracles">Oracles</a>
+        <a href="https://t.me/oraclesnetwork" className="social social_telegram">Telegram</a>
+        <a href="https://github.com/oraclesorg/" className="social social_github">GitHub</a>
+      </div>
+    </div>
+  </footer>
 )

--- a/src/components/Home/index.js
+++ b/src/components/Home/index.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import '../../assets/stylesheets/application.css';
-import { getWeb3, getNetworkVersion } from '../../utils/blockchainHelpers'
 import { Link } from 'react-router-dom'
 
 export class Home extends Component {
@@ -12,8 +11,8 @@ export class Home extends Component {
             <div className="container">
               <h1 className="title">Welcome to ICO Wizard</h1>
               <p className="description">
-              ICO Wizard is a client side tool to create token and crowdsale contracts in five steps. It helps you to publish contracts on the Ethereum network, verify them in Etherscan, create a crowdsale page with stats. For participants, the wizard creates a page to invest into the campaign. 
-              <br/>Smart contracts based on <a href="https://github.com/TokenMarketNet/ico">TokenMarket</a> contracts. 
+              ICO Wizard is a client side tool to create token and crowdsale contracts in five steps. It helps you to publish contracts on the Ethereum network, verify them in Etherscan, create a crowdsale page with stats. For participants, the wizard creates a page to invest into the campaign.
+              <br/>Smart contracts based on <a href="https://github.com/TokenMarketNet/ico">TokenMarket</a> contracts.
               </p>
               <div className="buttons">
                 <Link to='/1'><a className="button button_fill">New crowdsale</a></Link>

--- a/src/components/crowdsale/index.js
+++ b/src/components/crowdsale/index.js
@@ -95,8 +95,8 @@ export class Crowdsale extends React.Component {
     getCrowdsaleData(web3, crowdsaleContract)
       .then(() => initializeAccumulativeData())
       .then(() => {
-          this.setState({ loading: false })
-          getAccumulativeCrowdsaleData.call(this, web3, () => {})
+        this.setState({ loading: false })
+        getAccumulativeCrowdsaleData.call(this, web3, () => {})
       })
       .catch(err => {
         this.setState({ loading: false })

--- a/src/components/crowdsale/utils.js
+++ b/src/components/crowdsale/utils.js
@@ -101,86 +101,86 @@ export function getCrowdsaleTargetDates(web3, $this, cb) {
   for (let i = 0; i < contractStore.crowdsale.addr.length; i++) {
     let crowdsaleAddr = contractStore.crowdsale.addr[i];
     attachToContract(web3, contractStore.crowdsale.abi, crowdsaleAddr)
-      .then(crowdsaleContract => {
-      console.log("attach to crowdsale contract");
+      .then(crowdsaleContract => { // eslint-disable-line no-loop-func
+        console.log("attach to crowdsale contract");
 
-      if (!crowdsaleContract) return noContractAlert();
+        if (!crowdsaleContract) return noContractAlert();
 
-      if (crowdsaleContract.methods.startBlock) {
-        propsCount++;
-        crowdsaleContract.methods.startBlock().call((err, startBlock) => {
-          cbCount++;
-          if (err) return console.log(err);
-
-          console.log("startBlock: " + startBlock);
-          if (!crowdsalePageStore.startBlock || crowdsalePageStore.startBlock > startBlock)
-            crowdsalePageStore.setProperty('startBlock', startBlock);
-          if (propsCount === cbCount) {
-            state.loading = false;
-            $this.setState(state, cb);
-          }
-        });
-      }
-
-      if (crowdsaleContract.methods.startsAt) {
-        propsCount++;
-        crowdsaleContract.methods.startsAt().call((err, startDate) => {
-          cbCount++;
-          if (err) return console.log(err);
-
-          console.log("startDate: " + startDate*1000);
-          if (!crowdsalePageStore.startDate || crowdsalePageStore.startDate > startDate*1000)
-            crowdsalePageStore.startDate = startDate*1000;
-          if (propsCount === cbCount) {
-            state.loading = false;
-            $this.setState(state, cb);
-          }
-        });
-      }
-
-      if (crowdsaleContract.methods.endBlock) {
-        propsCount++;
-        crowdsaleContract.methods.endBlock().call((err, endBlock) => {
-          cbCount++;
-          if (err) return console.log(err);
-
-          console.log("endBlock: " + endBlock);
-          if (!crowdsalePageStore.endBlock || crowdsalePageStore.endBlock < endBlock)
-            crowdsalePageStore.endBlock = endBlock;
-          web3.eth.getBlockNumber((err, curBlock) => {
+        if (crowdsaleContract.methods.startBlock) {
+          propsCount++;
+          crowdsaleContract.methods.startBlock().call((err, startBlock) => {
+            cbCount++;
             if (err) return console.log(err);
 
-            console.log("curBlock: " + curBlock);
-            var blocksDiff = parseInt($this.crowdsalePageStore.endBlock, 10) - parseInt(curBlock, 10);
-            console.log("blocksDiff: " + blocksDiff);
-            var blocksDiffInSec = blocksDiff * state.blockTimeGeneration;
-            console.log("blocksDiffInSec: " + blocksDiffInSec);
-            state.seconds = blocksDiffInSec;
+            console.log("startBlock: " + startBlock);
+            if (!crowdsalePageStore.startBlock || crowdsalePageStore.startBlock > startBlock)
+              crowdsalePageStore.setProperty('startBlock', startBlock);
             if (propsCount === cbCount) {
               state.loading = false;
               $this.setState(state, cb);
             }
-           });
-        });
-      }
+          });
+        }
 
-      if (crowdsaleContract.methods.endsAt) {
-        propsCount++;
-        crowdsaleContract.methods.endsAt().call((err, endDate) => {
-          cbCount++;
-          if (err) return console.log(err);
+        if (crowdsaleContract.methods.startsAt) {
+          propsCount++;
+          crowdsaleContract.methods.startsAt().call((err, startDate) => {
+            cbCount++;
+            if (err) return console.log(err);
 
-          console.log("endDate: " + endDate*1000);
-          if (!crowdsalePageStore.endDate || crowdsalePageStore.endDate < endDate*1000)
-            crowdsalePageStore.endDate = endDate*1000;
-          console.log("curDate: " + new Date().getTime());
-          if (propsCount === cbCount) {
-            state.loading = false;
-            $this.setState(state, cb);
-          }
-      });
-      }
-    })
+            console.log("startDate: " + startDate*1000);
+            if (!crowdsalePageStore.startDate || crowdsalePageStore.startDate > startDate*1000)
+              crowdsalePageStore.startDate = startDate*1000;
+            if (propsCount === cbCount) {
+              state.loading = false;
+              $this.setState(state, cb);
+            }
+          });
+        }
+
+        if (crowdsaleContract.methods.endBlock) {
+          propsCount++;
+          crowdsaleContract.methods.endBlock().call((err, endBlock) => {
+            cbCount++;
+            if (err) return console.log(err);
+
+            console.log("endBlock: " + endBlock);
+            if (!crowdsalePageStore.endBlock || crowdsalePageStore.endBlock < endBlock)
+              crowdsalePageStore.endBlock = endBlock;
+            web3.eth.getBlockNumber((err, curBlock) => {
+              if (err) return console.log(err);
+
+              console.log("curBlock: " + curBlock);
+              var blocksDiff = parseInt($this.crowdsalePageStore.endBlock, 10) - parseInt(curBlock, 10);
+              console.log("blocksDiff: " + blocksDiff);
+              var blocksDiffInSec = blocksDiff * state.blockTimeGeneration;
+              console.log("blocksDiffInSec: " + blocksDiffInSec);
+              state.seconds = blocksDiffInSec;
+              if (propsCount === cbCount) {
+                state.loading = false;
+                $this.setState(state, cb);
+              }
+            });
+          });
+        }
+
+        if (crowdsaleContract.methods.endsAt) {
+          propsCount++;
+          crowdsaleContract.methods.endsAt().call((err, endDate) => {
+            cbCount++;
+            if (err) return console.log(err);
+
+            console.log("endDate: " + endDate*1000);
+            if (!crowdsalePageStore.endDate || crowdsalePageStore.endDate < endDate*1000)
+              crowdsalePageStore.endDate = endDate*1000;
+            console.log("curDate: " + new Date().getTime());
+            if (propsCount === cbCount) {
+              state.loading = false;
+              $this.setState(state, cb);
+            }
+          });
+        }
+      })
       .catch(console.log)
   }
 }
@@ -202,7 +202,7 @@ export function getAccumulativeCrowdsaleData(web3, cb) {
     let crowdsaleAddr = contractStore.crowdsale.addr[i];
 
     attachToContract(web3, contractStore.crowdsale.abi, crowdsaleAddr)
-      .then(crowdsaleContract => {
+      .then(crowdsaleContract => { // eslint-disable-line no-loop-func
         console.log('attach to crowdsale contract')
 
         if (!crowdsaleContract) return noContractAlert()
@@ -282,23 +282,24 @@ export function getAccumulativeCrowdsaleData(web3, cb) {
             cbCount++
             if (err) return console.log(err)
 
-          console.log("investors: " + investors);
-          let state = this.state;
-          const oldInvestors = crowdsalePageStore.investors
-          const investorsCount = parseInt(investors, 10)
+            console.log("investors: " + investors);
+            let state = this.state;
+            const oldInvestors = crowdsalePageStore.investors
+            const investorsCount = parseInt(investors, 10)
 
-          if (oldInvestors)
-            crowdsalePageStore.setProperty('investors', oldInvestors + investorsCount);
-          else
-            crowdsalePageStore.setProperty('investors', investorsCount);
+            if (oldInvestors)
+              crowdsalePageStore.setProperty('investors', oldInvestors + investorsCount);
+            else
+              crowdsalePageStore.setProperty('investors', investorsCount);
 
-          if (propsCount === cbCount) {
-            state.loading = false;
-            this.setState(state, cb);
-          }
-        });
-      }
-    }).catch(console.log)
+            if (propsCount === cbCount) {
+              state.loading = false;
+              this.setState(state, cb);
+            }
+          });
+        }
+      })
+      .catch(console.log)
   }
 }
 
@@ -328,7 +329,7 @@ function setMaximumSellableTokensInEth(web3, crowdsaleContract, maximumSellableT
 }
 
 export function getCurrentRate(web3, crowdsaleContract) {
-return new Promise((resolve, reject) => {
+  return new Promise((resolve, reject) => {
     if (!crowdsaleContract) {
       noContractAlert()
       reject('no contract')
@@ -440,7 +441,7 @@ export function getCrowdsaleData (web3, crowdsaleContract) {
 
             getPricingStrategyData(web3)
               .then(() => {
-              cbCount++
+                cbCount++
                 if (propsCount === cbCount) {
                   resolve()
                 }
@@ -455,220 +456,219 @@ export function getCrowdsaleData (web3, crowdsaleContract) {
 
 function getTokenData () {
   return new Promise((resolve, reject) => {
-      const { web3 } = web3Store
+    const { web3 } = web3Store
 
-      if (!web3) {
-        resolve('no MetaMask')
+    if (!web3) {
+      resolve('no MetaMask')
+      return
+    }
+
+    web3.eth.getAccounts().then(accounts => {
+      if (accounts.length === 0) {
+        resolve('no accounts')
         return
       }
 
-      web3.eth.getAccounts().then(accounts => {
-        if (accounts.length === 0) {
-          resolve('no accounts')
-          return
-        }
+      let propsCount = 0
+      let cbCount = 0
+      let tokenObj = toJS(contractStore.token)
+      console.log('tokenObj', tokenObj)
 
-        let propsCount = 0
-        let cbCount = 0
-        let tokenObj = toJS(contractStore.token)
-        console.log('tokenObj', tokenObj)
+      attachToContract(web3, tokenObj.abi, tokenObj.addr)
+        .then(tokenContract => {
+          console.log('attach to token contract')
 
-        attachToContract(web3, tokenObj.abi, tokenObj.addr)
-          .then(tokenContract => {
-            console.log('attach to token contract')
+          if (!tokenContract) {
+            noContractAlert()
+            reject('no contract')
+            return
+          }
 
-            if (!tokenContract) {
-              noContractAlert()
-              reject('no contract')
-              return
+          propsCount++
+          tokenContract.methods.name().call((err, name) => {
+            cbCount++
+
+            if (err) {
+              return console.log(err)
             }
 
+            console.log('token name:', name)
+            tokenStore.setProperty('name', name)
+
+            if (propsCount === cbCount) {
+              resolve()
+            }
+          })
+
+          propsCount++
+          tokenContract.methods.symbol().call((err, ticker) => {
+            cbCount++
+
+            if (err) {
+              console.log(err)
+            }
+
+            console.log('token ticker: ' + ticker)
+            tokenStore.setProperty('ticker', ticker)
+
+            if (propsCount === cbCount) {
+              resolve()
+            }
+          })
+
+          if (tokenContract.methods.balanceOf) {
             propsCount++
-            tokenContract.methods.name().call((err, name) => {
+            tokenContract.methods.balanceOf.call(accounts[0], (err, balanceOf) => {
               cbCount++
 
               if (err) {
                 return console.log(err)
               }
 
-              console.log('token name:', name)
-              tokenStore.setProperty('name', name)
+              console.log('balanceOf: ' + balanceOf)
+              const tokenAmountOf = crowdsalePageStore.tokenAmountOf ? crowdsalePageStore.tokenAmountOf : 0
+              crowdsalePageStore.setProperty('tokenAmountOf', tokenAmountOf + parseInt(balanceOf, 10))
 
               if (propsCount === cbCount) {
                 resolve()
               }
             })
+          }
 
-            propsCount++
-            tokenContract.methods.symbol().call((err, ticker) => {
-              cbCount++
+          propsCount++
+          tokenContract.methods.decimals().call((err, decimals) => {
+            cbCount++
 
-              if (err) {
-                console.log(err)
-              }
-
-              console.log('token ticker: ' + ticker)
-              tokenStore.setProperty('ticker', ticker)
-
-              if (propsCount === cbCount) {
-                resolve()
-              }
-            })
-
-            if (tokenContract.methods.balanceOf) {
-              propsCount++
-              tokenContract.methods.balanceOf.call(accounts[0], (err, balanceOf) => {
-                cbCount++
-
-                if (err) {
-                  return console.log(err)
-                }
-
-                console.log('balanceOf: ' + balanceOf)
-                const tokenAmountOf = crowdsalePageStore.tokenAmountOf ? crowdsalePageStore.tokenAmountOf : 0
-                crowdsalePageStore.setProperty('tokenAmountOf', tokenAmountOf + parseInt(balanceOf, 10))
-
-                if (propsCount === cbCount) {
-                  resolve()
-                }
-              })
+            if (err) {
+              console.log(err)
             }
 
-            propsCount++
-            tokenContract.methods.decimals().call((err, decimals) => {
-              cbCount++
+            console.log('token decimals:', decimals)
+            tokenStore.setProperty('decimals', decimals)
 
-              if (err) {
-                console.log(err)
-              }
+            if (propsCount === cbCount) {
+              resolve()
+            }
+          })
 
-              console.log('token decimals:', decimals)
-              tokenStore.setProperty('decimals', decimals)
+          propsCount++
+          tokenContract.methods.totalSupply().call((err, supply) => {
+            cbCount++
 
-              if (propsCount === cbCount) {
-                resolve()
-              }
-            })
+            if (err) {
+              console.log(err)
+            }
 
-            propsCount++
-            tokenContract.methods.totalSupply().call((err, supply) => {
-              cbCount++
+            console.log('token supply:', supply)
+            tokenStore.setProperty('supply', supply)
 
-              if (err) {
-                console.log(err)
-              }
+            if (propsCount === cbCount) {
+              resolve()
 
-              console.log('token supply:', supply)
-              tokenStore.setProperty('supply', supply)
+            } else {
+              let propsCount = 0
+              let cbCount = 0
 
-              if (propsCount === cbCount) {
-                resolve()
+              attachToContract(web3, contractStore.token.abi, contractStore.token.addr)
+                .then(tokenContract => {
+                  console.log('attach to token contract')
 
-              } else {
-                let propsCount = 0
-                let cbCount = 0
+                  if (!tokenContract) {
+                    noContractAlert()
+                    reject('no contract')
+                    return
+                  }
 
-                attachToContract(web3, contractStore.token.abi, contractStore.token.addr)
-                  .then(tokenContract => {
-                    console.log('attach to token contract')
+                  propsCount++
+                  tokenContract.methods.name().call((err, name) => {
+                    cbCount++
 
-                    if (!tokenContract) {
-                      noContractAlert()
-                      reject('no contract')
-                      return
+                    if (err) {
+                      return console.log(err)
                     }
 
+                    console.log('token name:', name)
+                    tokenStore.setProperty('name', name)
+
+                    if (propsCount === cbCount) {
+                      resolve()
+                    }
+                  })
+
+                  propsCount++
+                  tokenContract.methods.symbol().call((err, ticker) => {
+                    cbCount++
+
+                    if (err) {
+                      console.log(err)
+                    }
+
+                    console.log('token ticker:', ticker)
+                    tokenStore.setProperty('ticker', ticker)
+
+                    if (propsCount === cbCount) {
+                      resolve()
+                    }
+                  })
+
+                  if (tokenContract.methods.balanceOf) {
                     propsCount++
-                    tokenContract.methods.name().call((err, name) => {
+                    tokenContract.methods.balanceOf(accounts[0]).call((err, balanceOf) => {
                       cbCount++
 
                       if (err) {
                         return console.log(err)
                       }
 
-                      console.log('token name:', name)
-                      tokenStore.setProperty('name', name)
+                      console.log('balanceOf:', balanceOf)
+                      const tokenAmountOf = crowdsalePageStore.tokenAmountOf ? crowdsalePageStore.tokenAmountOf : 0
+                      crowdsalePageStore.setProperty('tokenAmountOf', tokenAmountOf + parseInt(balanceOf, 10))
 
                       if (propsCount === cbCount) {
                         resolve()
                       }
                     })
+                  }
 
-                    propsCount++
-                    tokenContract.methods.symbol().call((err, ticker) => {
-                      cbCount++
+                  propsCount++
+                  tokenContract.methods.decimals().call((err, decimals) => {
+                    cbCount++
 
-                      if (err) {
-                        console.log(err)
-                      }
-
-                      console.log('token ticker:', ticker)
-                      tokenStore.setProperty('ticker', ticker)
-
-                      if (propsCount === cbCount) {
-                        resolve()
-                      }
-                    })
-
-                    if (tokenContract.methods.balanceOf) {
-                      propsCount++
-                      tokenContract.methods.balanceOf(accounts[0]).call((err, balanceOf) => {
-                        cbCount++
-
-                        if (err) {
-                          return console.log(err)
-                        }
-
-                        console.log('balanceOf:', balanceOf)
-                        const tokenAmountOf = crowdsalePageStore.tokenAmountOf ? crowdsalePageStore.tokenAmountOf : 0
-                        crowdsalePageStore.setProperty('tokenAmountOf', tokenAmountOf + parseInt(balanceOf, 10))
-
-                        if (propsCount === cbCount) {
-                          resolve()
-                        }
-                      })
+                    if (err) {
+                      console.log(err)
                     }
 
-                    propsCount++
-                    tokenContract.methods.decimals().call((err, decimals) => {
-                      cbCount++
+                    console.log('token decimals:', decimals)
+                    tokenStore.setProperty('decimals', decimals)
 
-                      if (err) {
-                        console.log(err)
-                      }
-
-                      console.log('token decimals:', decimals)
-                      tokenStore.setProperty('decimals', decimals)
-
-                      if (propsCount === cbCount) {
-                        resolve()
-                      }
-                    })
-
-                    propsCount++
-                    tokenContract.methods.totalSupply().call((err, supply) => {
-                      cbCount++
-
-                      if (err) {
-                        console.log(err)
-                      }
-
-                      console.log('token supply:', supply)
-                      tokenStore.setProperty('supply', supply)
-
-                      if (propsCount === cbCount) {
-                        resolve()
-                      }
-                    })
+                    if (propsCount === cbCount) {
+                      resolve()
+                    }
                   })
-                  .catch(reject)
-              }
-            })
+
+                  propsCount++
+                  tokenContract.methods.totalSupply().call((err, supply) => {
+                    cbCount++
+
+                    if (err) {
+                      console.log(err)
+                    }
+
+                    console.log('token supply:', supply)
+                    tokenStore.setProperty('supply', supply)
+
+                    if (propsCount === cbCount) {
+                      resolve()
+                    }
+                  })
+                })
+                .catch(reject)
+            }
           })
-          .catch(reject)
-      })
-    }
-  )
+        })
+        .catch(reject)
+    })
+  })
 }
 
 export function getPricingStrategyData (web3) {

--- a/src/components/invest/index.js
+++ b/src/components/invest/index.js
@@ -8,8 +8,7 @@ import {
   getCrowdsaleData,
   getCrowdsaleTargetDates,
   getCurrentRate,
-  getJoinedTiers,
-  initializeAccumulativeData
+  getJoinedTiers
 } from '../crowdsale/utils'
 import { getQueryVariable, getURLParam, getWhiteListWithCapCrowdsaleAssets, toast } from '../../utils/utils'
 import {
@@ -28,17 +27,17 @@ import QRPaymentProcess from './QRPaymentProcess'
 @observer
 export class Invest extends React.Component {
   constructor(props) {
-      super(props);
-      window.scrollTo(0, 0);
+    super(props);
+    window.scrollTo(0, 0);
 
-      this.state = {
-        seconds: 0,
-        loading: true,
-        pristineTokenInput: true,
-        web3Available: false,
-        investThrough: INVESTMENT_OPTIONS.QR,
-        crowdsaleAddress: ICOConfig.crowdsaleContractURL || getURLParam("addr")
-      }
+    this.state = {
+      seconds: 0,
+      loading: true,
+      pristineTokenInput: true,
+      web3Available: false,
+      investThrough: INVESTMENT_OPTIONS.QR,
+      crowdsaleAddress: ICOConfig.crowdsaleContractURL || getURLParam("addr")
+    }
   }
 
   componentDidMount () {
@@ -66,7 +65,7 @@ export class Invest extends React.Component {
       .then(_newState => {
         this.setState(_newState)
         this.extractContractsData(web3)
-    })
+      })
   }
 
   extractContractsData(web3) {

--- a/src/components/stepFour/index.js
+++ b/src/components/stepFour/index.js
@@ -72,9 +72,9 @@ const { PUBLISH } = NAVIGATION_STEPS
       }
 
       const { token, pricingStrategy } = contractStore
-      const abiToken = token && token.abi || []
-      const addrToken = token && token.addr || null
-      const abiPricingStrategy = pricingStrategy && pricingStrategy.abi || []
+      const abiToken = (token && token.abi) || []
+      const addrToken = (token && token.addr) || null
+      const abiPricingStrategy = (pricingStrategy && pricingStrategy.abi) || []
 
       const tokenABIConstructor = Promise.resolve(addrToken)
         .then(addrToken => {
@@ -134,6 +134,8 @@ const { PUBLISH } = NAVIGATION_STEPS
         return handleContractsForFile(content, index, this.props.contractStore, this.props.tierStore)
       case 'none':
         return handleConstantForFile(content)
+      default:
+        // do nothing
     }
   }
 
@@ -238,8 +240,8 @@ const { PUBLISH } = NAVIGATION_STEPS
       return Promise.reject('no MetaMask')
     }
 
-    const binToken = contractStore && contractStore.token && contractStore.token.bin || ''
-    const abiToken = contractStore && contractStore.token && contractStore.token.abi || []
+    const binToken = (contractStore && contractStore.token && contractStore.token.bin) || ''
+    const abiToken = (contractStore && contractStore.token && contractStore.token.abi) || []
     const paramsToken = this.getTokenParams(tokenStore)
 
     console.log(paramsToken);
@@ -283,8 +285,8 @@ const { PUBLISH } = NAVIGATION_STEPS
     }
 
     const pricingStrategies = tierStore.tiers
-    const binPricingStrategy = contractStore && contractStore.pricingStrategy && contractStore.pricingStrategy.bin || ''
-    const abiPricingStrategy = contractStore && contractStore.pricingStrategy && contractStore.pricingStrategy.abi || []
+    const binPricingStrategy = (contractStore && contractStore.pricingStrategy && contractStore.pricingStrategy.bin) || ''
+    const abiPricingStrategy = (contractStore && contractStore.pricingStrategy && contractStore.pricingStrategy.abi) || []
 
     return pricingStrategies.reduce((promise, pricingStrategy, index) => {
       const paramsPricingStrategy = this.getPricingStrategyParams(pricingStrategy)
@@ -321,7 +323,7 @@ const { PUBLISH } = NAVIGATION_STEPS
     const { contractStore, tierStore, web3Store } = this.props
     const { web3 } = web3Store
 
-    const abiCrowdsale = contractStore && contractStore.crowdsale && contractStore.crowdsale.abi || []
+    const abiCrowdsale = (contractStore && contractStore.crowdsale && contractStore.crowdsale.abi) || []
 
     return tierStore.tiers.reduce((promise, tier, index) => {
       return promise
@@ -350,8 +352,8 @@ const { PUBLISH } = NAVIGATION_STEPS
         }
 
         contractStore.setContractProperty('crowdsale', 'networkID', networkID)
-        const binCrowdsale = contractStore.crowdsale && contractStore.crowdsale.bin || ''
-        const abiCrowdsale = contractStore.crowdsale && contractStore.crowdsale.abi || []
+        const binCrowdsale = (contractStore.crowdsale && contractStore.crowdsale.bin) || ''
+        const abiCrowdsale = (contractStore.crowdsale && contractStore.crowdsale.abi) || []
 
         return tierStore.tiers.reduce((promise, tier, index) => {
           console.log('***Deploy crowdsale contract***', index)
@@ -399,11 +401,11 @@ const { PUBLISH } = NAVIGATION_STEPS
     const { web3Store, contractStore, tierStore } = this.props
     const { web3 } = web3Store
     const tiersMaxIndex = tierStore.tiers.length - 1
-    let abiFinalizeAgent = contractStore.nullFinalizeAgent && contractStore.nullFinalizeAgent.abi || []
+    let abiFinalizeAgent = (contractStore.nullFinalizeAgent && contractStore.nullFinalizeAgent.abi) || []
 
     return Promise.all(tierStore.tiers.map((tier, index) => {
       if (index === tiersMaxIndex) {
-        abiFinalizeAgent = contractStore.finalizeAgent && contractStore.finalizeAgent.abi || []
+        abiFinalizeAgent = (contractStore.finalizeAgent && contractStore.finalizeAgent.abi) || []
       }
 
       return getEncodedABIClientSide(web3, abiFinalizeAgent, [], index)
@@ -426,11 +428,11 @@ const { PUBLISH } = NAVIGATION_STEPS
       return Promise.reject('no MetaMask')
     }
 
-    let binNullFinalizeAgent = contractStore && contractStore.nullFinalizeAgent && contractStore.nullFinalizeAgent.bin || ''
-    let abiNullFinalizeAgent = contractStore && contractStore.nullFinalizeAgent && contractStore.nullFinalizeAgent.abi || []
+    let binNullFinalizeAgent = (contractStore && contractStore.nullFinalizeAgent && contractStore.nullFinalizeAgent.bin) || ''
+    let abiNullFinalizeAgent = (contractStore && contractStore.nullFinalizeAgent && contractStore.nullFinalizeAgent.abi) || []
 
-    let binFinalizeAgent = contractStore && contractStore.finalizeAgent && contractStore.finalizeAgent.bin || ''
-    let abiFinalizeAgent = contractStore && contractStore.finalizeAgent && contractStore.finalizeAgent.abi || []
+    let binFinalizeAgent = (contractStore && contractStore.finalizeAgent && contractStore.finalizeAgent.bin) || ''
+    let abiFinalizeAgent = (contractStore && contractStore.finalizeAgent && contractStore.finalizeAgent.abi) || []
 
     let crowdsales
 

--- a/src/components/stepFour/utils.js
+++ b/src/components/stepFour/utils.js
@@ -349,7 +349,7 @@ export const handleContractsForFile = (content, index, contractStore, tierStore)
       fileBody = contractField[index]
 
       if (!!fileBody) {
-          fileContent = title + ' for ' + tierStore.tiers[index].tier + ':**** \n\n' + fileBody
+        fileContent = title + ' for ' + tierStore.tiers[index].tier + ':**** \n\n' + fileBody
       }
     } else if (!!contractField) {
       fileContent = title + ':**** \n\n' + contractField
@@ -368,7 +368,7 @@ const addSrcToFile = (content, index, contractStore, tierStore) => {
   let fileContent = ''
 
   if (isObservableArray(contractField) && field !== 'abi') {
-      fileContent = title + ' for ' + tierStore.tiers[index].tier + ': ' + contractField[index]
+    fileContent = title + ' for ' + tierStore.tiers[index].tier + ': ' + contractField[index]
   } else {
     if (field !== 'src') {
       const body = field === 'abi' ? JSON.stringify(contractField) : contractField

--- a/src/components/stepOne/index.js
+++ b/src/components/stepOne/index.js
@@ -1,12 +1,11 @@
 import React from 'react'
 import '../../assets/stylesheets/application.css';
-import { checkWeb3, getWeb3, getNetworkVersion } from '../../utils/blockchainHelpers'
+import { checkWeb3 } from '../../utils/blockchainHelpers'
 import { Link } from 'react-router-dom';
 import { setFlatFileContentToState } from '../../utils/utils';
 import { StepNavigation } from '../Common/StepNavigation';
 import { NAVIGATION_STEPS, CONTRACT_TYPES } from '../../utils/constants';
 import { inject, observer } from 'mobx-react';
-import { noDeploymentOnMainnetAlert } from '../../utils/alerts'
 const { CROWDSALE_CONTRACT } = NAVIGATION_STEPS;
 
 

--- a/src/components/stepThree/index.js
+++ b/src/components/stepThree/index.js
@@ -150,13 +150,13 @@ export class stepThree extends React.Component{
     </div>
   }
 
-    componentDidMount () {
-      const { tierStore, web3Store } = this.props
-      const { curAddress } = web3Store
-      tierStore.setTierProperty(curAddress, 'walletAddress', 0)
-      tierStore.setTierProperty(defaultCompanyStartDate(), 'startTime', 0)
-      tierStore.setTierProperty(defaultCompanyEndDate(tierStore.tiers[0].startTime), 'endTime', 0)
-    }
+  componentDidMount () {
+    const { tierStore, web3Store } = this.props
+    const { curAddress } = web3Store
+    tierStore.setTierProperty(curAddress, 'walletAddress', 0)
+    tierStore.setTierProperty(defaultCompanyStartDate(), 'startTime', 0)
+    tierStore.setTierProperty(defaultCompanyEndDate(tierStore.tiers[0].startTime), 'endTime', 0)
+  }
 
   render() {
     const { contractStore, pricingStrategyStore, crowdsaleBlockListStore, tierStore } = this.props

--- a/src/components/stepThree/utils.js
+++ b/src/components/stepThree/utils.js
@@ -1,8 +1,8 @@
 export function defaultCompanyStartDate() {
-    let curDate = new Date();
-    curDate = new Date(curDate).setUTCHours(new Date().getHours());
-    curDate = new Date(curDate).setMinutes(new Date(curDate).getMinutes() + 5);
-    let curDateISO = new Date(curDate).toISOString();
-    let targetDate = curDateISO.split(".")[0].substring(0, curDateISO.lastIndexOf(":"))
-    return targetDate;
+  let curDate = new Date();
+  curDate = new Date(curDate).setUTCHours(new Date().getHours());
+  curDate = new Date(curDate).setMinutes(new Date(curDate).getMinutes() + 5);
+  let curDateISO = new Date(curDate).toISOString();
+  let targetDate = curDateISO.split(".")[0].substring(0, curDateISO.lastIndexOf(":"))
+  return targetDate;
 }

--- a/src/components/stepTwo/index.js
+++ b/src/components/stepTwo/index.js
@@ -39,7 +39,7 @@ export class stepTwo extends Component {
 
   render() {
     return (
-    	<section className="steps steps_crowdsale-contract" ref="two">
+      <section className="steps steps_crowdsale-contract" ref="two">
         <StepNavigation activeStep={TOKEN_SETUP}/>
         <div className="steps-content container">
           <div className="about-step">
@@ -86,5 +86,5 @@ export class stepTwo extends Component {
           {this.renderLinkComponent()}
         </div>
       </section>
-  )}
+    )}
 }

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,6 @@ useStrict(true);
 ReactDOM.render(
   <Provider { ...stores }>
     <App />
-  </Provider>, 
+  </Provider>,
 document.getElementById('root'));
 registerServiceWorker();

--- a/src/stores/CrowdsaleBlockListStore.js
+++ b/src/stores/CrowdsaleBlockListStore.js
@@ -3,7 +3,7 @@ import { observable, action } from 'mobx';
 class CrowdsaleBlockListStore {
 
   @observable blockList;
-  
+
   constructor(blockList = []) {
     this.blockList = blockList;
   }
@@ -11,20 +11,20 @@ class CrowdsaleBlockListStore {
   @action addCrowdsaleItem = (crowdsaleBlock) => {
     this.blockList.push(crowdsaleBlock)
   }
-  
+
   @action setCrowdsaleItemProperty = (index, property, value) => {
     let newCrowdsaleItem = {...this.blockList[index]}
     newCrowdsaleItem[property] = value
     this.blockList[index] = newCrowdsaleItem;
   }
-  
+
   @action removeCrowdsaleItem = (index) => {
     this.blockList.splice(index,1)
   }
 
-	@action emptyList = () => {
-		this.blockList = []
-	}
+  @action emptyList = () => {
+    this.blockList = []
+  }
 
 }
 

--- a/src/stores/CrowdsalePageStore.js
+++ b/src/stores/CrowdsalePageStore.js
@@ -2,19 +2,19 @@ import { observable, action } from 'mobx';
 
 class CrowdsalePageStore {
 
-	@observable maximumSellableTokens;
-	@observable maximumSellableTokensInWei;
-	@observable investors;
-	@observable ethRaised;
-	@observable weiRaised;
-	@observable rate;
-	@observable tokensSold;
-	@observable tokenAmountOf;
-	@observable startBlock
-	@observable endDate;
+  @observable maximumSellableTokens;
+  @observable maximumSellableTokensInWei;
+  @observable investors;
+  @observable ethRaised;
+  @observable weiRaised;
+  @observable rate;
+  @observable tokensSold;
+  @observable tokenAmountOf;
+  @observable startBlock
+  @observable endDate;
 
   @action setProperty = (property, value) => {
-		this[property] = value
+    this[property] = value
   }
 
 }

--- a/src/stores/GeneralStore.js
+++ b/src/stores/GeneralStore.js
@@ -3,9 +3,9 @@ import { observable, action } from 'mobx';
 class GeneralStore {
 
   @observable networkId;
-  
+
   @action setProperty = (property, value) => {
-		this[property] = value
+    this[property] = value
   }
 
 }

--- a/src/stores/InvestStore.js
+++ b/src/stores/InvestStore.js
@@ -2,10 +2,10 @@ import { observable, action } from 'mobx';
 
 class InvestStore {
 
-	@observable tokensToInvest;
+  @observable tokensToInvest;
 
   @action setProperty = (property, value) => {
-		this[property] = value
+    this[property] = value
   }
 
 }

--- a/src/stores/PricingStrategyStore.js
+++ b/src/stores/PricingStrategyStore.js
@@ -2,25 +2,25 @@ import { observable, action } from 'mobx';
 
 class PricingStrategyStore {
 
-	@observable strategies;
-	
-	constructor(strategies = []) {
+  @observable strategies;
+
+  constructor(strategies = []) {
     this.strategies = strategies;
   }
 
   @action addStrategy = (strategy) => {
     this.strategies.push(strategy)
-	}
-	
-	@action setStrategyProperty = (value, property, index) => {
-		let newStrategy = {...this.strategies[index]}
-		newStrategy[property] = value
+  }
+
+  @action setStrategyProperty = (value, property, index) => {
+    let newStrategy = {...this.strategies[index]}
+    newStrategy[property] = value
     this.strategies[index] = newStrategy;
-	}
-	
-	@action removeStrategy = (index) => {
-		this.strategies.splice(index,1)
-	}
+  }
+
+  @action removeStrategy = (index) => {
+    this.strategies.splice(index,1)
+  }
 
 }
 

--- a/src/stores/ReservedTokenElementStore.js
+++ b/src/stores/ReservedTokenElementStore.js
@@ -2,25 +2,25 @@ import { observable, action } from 'mobx';
 
 class ReservedTokensElementStore {
 
-	@observable tokenElements;
-	
-	constructor(tokenElements = []) {
+  @observable tokenElements;
+
+  constructor(tokenElements = []) {
     this.tokenElements = tokenElements;
   }
 
   @action addToken = (token) => {
     this.tokenElements.push(token)
-	}
-	
-	@action setTokenProperty = (index, property, value) => {
-		let newToken = {...this.tokenElements[index]}
-		newToken[property] = value
+  }
+
+  @action setTokenProperty = (index, property, value) => {
+    let newToken = {...this.tokenElements[index]}
+    newToken[property] = value
     this.tokenElements[index] = newToken;
-	}
-	
-	@action removeElement = (index) => {
-		this.tokenElements.splice(index,1)
-	}
+  }
+
+  @action removeElement = (index) => {
+    this.tokenElements.splice(index,1)
+  }
 
 
 }

--- a/src/stores/StepThreeValidationStore.js
+++ b/src/stores/StepThreeValidationStore.js
@@ -2,26 +2,26 @@ import { observable, action } from 'mobx';
 
 class StepThreeValidationStore {
 
-	@observable validationsList 
+  @observable validationsList
 
-	constructor() {
-		this[0] = {}
-		this[0].name = 'EMPTY'
-		this[0].walletAddress = 'EMPTY'
-		this[0].rate = 'EMPTY'
-		this[0].supply = 'EMPTY'
-		this[0].startTime = 'VALIDATED'
-		this[0].endTime = 'VALIDATED'
-		this[0].updatable = "VALIDATED"
-	}
+  constructor() {
+    this[0] = {}
+    this[0].name = 'EMPTY'
+    this[0].walletAddress = 'EMPTY'
+    this[0].rate = 'EMPTY'
+    this[0].supply = 'EMPTY'
+    this[0].startTime = 'VALIDATED'
+    this[0].endTime = 'VALIDATED'
+    this[0].updatable = "VALIDATED"
+  }
 
-	@action changeProperty = (index, property, value) => {
-		this[index][property] = value
-	}
+  @action changeProperty = (index, property, value) => {
+    this[index][property] = value
+  }
 
-	@action addValidationItem = (item) => {
-		this.validationsList.push(item)
-	}
+  @action addValidationItem = (item) => {
+    this.validationsList.push(item)
+  }
 
 
 }

--- a/src/stores/StepTwoValidationStore.js
+++ b/src/stores/StepTwoValidationStore.js
@@ -3,18 +3,18 @@ import { observable, action } from 'mobx';
 class StepTwoValidationStore {
 
   @observable name;
-	@observable ticker;
-	@observable decimals;
+  @observable ticker;
+  @observable decimals;
 
-	constructor() {
-		this.name = 'EMPTY'
-		this.ticker = 'EMPTY'
-		this.decimals = 'EMPTY'
-	}
+  constructor() {
+    this.name = 'EMPTY'
+    this.ticker = 'EMPTY'
+    this.decimals = 'EMPTY'
+  }
 
-	@action property = (property, value) => {
-		this[property] = value
-	}
+  @action property = (property, value) => {
+    this[property] = value
+  }
 
 }
 

--- a/src/stores/TierCrowdsaleListStore.js
+++ b/src/stores/TierCrowdsaleListStore.js
@@ -3,7 +3,7 @@ import { observable, action } from 'mobx';
 class TierCrowdsaleListStore {
 
   @observable crowdsaleList;
-  
+
   constructor(crowdsaleList = []) {
     this.crowdsaleList = crowdsaleList;
   }
@@ -11,13 +11,13 @@ class TierCrowdsaleListStore {
   @action addCrowdsaleItem = (crowdsaleItem) => {
     this.crowdsaleList.push(crowdsaleItem)
   }
-  
+
   @action setCrowdsaleItemProperty = (index, property, value) => {
     let newCrowdsaleItem = {...this.crowdsaleList[index]}
     newCrowdsaleItem[property] = value
     this.crowdsaleList[index] = newCrowdsaleItem;
   }
-  
+
   @action removeCrowdsaleItem = (index) => {
     this.crowdsaleList.splice(index,1)
   }

--- a/src/stores/TierStore.js
+++ b/src/stores/TierStore.js
@@ -1,35 +1,35 @@
 import { observable, action, computed } from 'mobx';
 import { VALIDATION_TYPES, defaultTiers } from '../utils/constants'
 import { validateName, validateTime, validateSupply, validateRate, validateAddress, validateLaterTime, validateLaterOrEqualTime } from '../utils/utils'
-const { VALID, INVALID, EMPTY } = VALIDATION_TYPES
+const { VALID, INVALID } = VALIDATION_TYPES
 class TierStore {
 
   @observable tiers;
   @observable validTiers;
   @observable globalMinCap;
 
-	constructor(tiers = defaultTiers) {
-		this.tiers = tiers;
-		this.validTiers = [{
-			name: 'VALIDATED',
-			walletAddress: 'VALIDATED',
-			rate: 'EMPTY',
-			supply: 'EMPTY',
-			startTime: 'VALIDATED',
-			endTime: 'VALIDATED',
-			updatable: "VALIDATED"
-		}]
-	}
+  constructor(tiers = defaultTiers) {
+    this.tiers = tiers;
+    this.validTiers = [{
+      name: 'VALIDATED',
+      walletAddress: 'VALIDATED',
+      rate: 'EMPTY',
+      supply: 'EMPTY',
+      startTime: 'VALIDATED',
+      endTime: 'VALIDATED',
+      updatable: "VALIDATED"
+    }]
+  }
 
-	@action setGlobalMinCap = (minCap) => {
-		this.globalmincap = minCap
-	}
+  @action setGlobalMinCap = (minCap) => {
+    this.globalmincap = minCap
+  }
 
   @action addTier = (tier) => {
-		this.tiers.push(tier)
-		console.log('tier', tier)
-		console.log('this.tiers', this.tiers)
-	}
+    this.tiers.push(tier)
+    console.log('tier', tier)
+    console.log('this.tiers', this.tiers)
+  }
 
   @action addTierValidations = (validations) => {
     this.validTiers.push(validations)
@@ -57,7 +57,7 @@ class TierStore {
       case 'name':
         this.validTiers[index][property] = validateName(this.tiers[index][property]) ? VALID : INVALID
         return
-        case 'walletAddress':
+      case 'walletAddress':
         this.validTiers[index][property] = validateAddress(this.tiers[index][property]) ? VALID : INVALID
         return
       case 'supply':
@@ -76,6 +76,8 @@ class TierStore {
       case 'endTime':
         this.validTiers[index][property] = validateLaterTime(this.tiers[index][property], this.tiers[index].startTime) ? VALID : INVALID
         return
+      default:
+        // do nothing
     }
   }
 
@@ -100,7 +102,7 @@ class TierStore {
     if (!this.validTiers) {
       return;
     }
-    this.validTiers.every((tier, index) => {
+    this.validTiers.forEach((tier, index) => {
       Object.keys(tier).forEach(key => {
         if (this.validTiers[index][key] === 'EMPTY') {
           this.validTiers[index][key] = 'INVALID';

--- a/src/stores/TokenStore.js
+++ b/src/stores/TokenStore.js
@@ -27,7 +27,7 @@ class TokenStore {
   @action setProperty = (property, value) => {
     this[property] = value;
   }
-  
+
   @action validateTokens = (property) => {
     if (property === 'name') {
       this.validToken[property] = validateName(this.name) ? VALID : INVALID;
@@ -49,13 +49,13 @@ class TokenStore {
       }
     });
   }
-  
-  // Getters 
+
+  // Getters
   @computed get isTokenValid() {
     if (!this.validToken) {
       return;
     }
-    
+
     const validKeys = Object.keys(this.validToken).filter((key) => {
       if (this.validToken[key] === VALID) {
         return true;

--- a/src/stores/Web3Store.js
+++ b/src/stores/Web3Store.js
@@ -3,12 +3,12 @@ import { getWeb3 } from '../utils/blockchainHelpers'
 
 class Web3Store {
 
-	@observable web3;
-	@observable curAddress
-	@observable accounts 
+  @observable web3;
+  @observable curAddress
+  @observable accounts
 
-	constructor(strategies) {
-		getWeb3((web3) => {
+  constructor(strategies) {
+    getWeb3((web3) => {
       if (web3) {
         this.web3 = web3
         web3.eth.getAccounts().then((accounts) => {
@@ -16,8 +16,8 @@ class Web3Store {
           this.curAddress = accounts[0]
         })
       }
-		})
-	}
+    })
+  }
 }
 
 const web3Store = new Web3Store();

--- a/src/utils/alerts.js
+++ b/src/utils/alerts.js
@@ -2,113 +2,113 @@ import sweetAlert from 'sweetalert';
 import 'sweetalert/dist/sweetalert.css';
 
 export function noMetaMaskAlert() {
-    sweetAlert({
-      title: "Warning",
-      text: "You don't have Metamask installed. Check ICO Wizard GitHub for <a href='https://github.com/oraclesorg/ico-wizard' target='blank'>the instruction</a>.",
-      html: true,
-      type: "warning"
-    });
+  sweetAlert({
+    title: "Warning",
+    text: "You don't have Metamask installed. Check ICO Wizard GitHub for <a href='https://github.com/oraclesorg/ico-wizard' target='blank'>the instruction</a>.",
+    html: true,
+    type: "warning"
+  });
 }
 
 export function noContractDataAlert() {
-    sweetAlert({
-      title: "Warning",
-      text: "The crowdsale data is empty. There is nothing to deploy. Please, start ICO Wizard from the beginning.",
-      html: true,
-      type: "warning"
-    });
+  sweetAlert({
+    title: "Warning",
+    text: "The crowdsale data is empty. There is nothing to deploy. Please, start ICO Wizard from the beginning.",
+    html: true,
+    type: "warning"
+  });
 }
 
 export function noContractAlert() {
-    sweetAlert({
-      title: "Warning",
-      text: "There is no contract at this address",
-      html: true,
-      type: "warning"
-    });
+  sweetAlert({
+    title: "Warning",
+    text: "There is no contract at this address",
+    html: true,
+    type: "warning"
+  });
 }
 
 export function invalidCrowdsaleAddrAlert() {
-    sweetAlert({
-      title: "Warning",
-      text: "Invalid crowdsale address is indicated in config and/or in query string.",
-      html: true,
-      type: "warning"
-    });
+  sweetAlert({
+    title: "Warning",
+    text: "Invalid crowdsale address is indicated in config and/or in query string.",
+    html: true,
+    type: "warning"
+  });
 }
 
 export function invalidNetworkIDAlert() {
-    sweetAlert({
-      title: "Warning",
-      text: "Invalid network ID is indicated in config and/or in query string.",
-      html: true,
-      type: "warning"
-    });
+  sweetAlert({
+    title: "Warning",
+    text: "Invalid network ID is indicated in config and/or in query string.",
+    html: true,
+    type: "warning"
+  });
 }
 
 export function successfulInvestmentAlert(tokensToInvest) {
-    sweetAlert({
-        title: "Success",
-        text: "Congrats! You've successfully bought " + tokensToInvest + " tokens!",
-        html: true,
-        type: "success"
-    }, function() {
-        window.location.reload();
-    });
+  sweetAlert({
+    title: "Success",
+    text: "Congrats! You've successfully bought " + tokensToInvest + " tokens!",
+    html: true,
+    type: "success"
+  }, function() {
+    window.location.reload();
+  });
 }
 
 export function investmentDisabledAlert(startBlock, curBlock) {
-    sweetAlert({
-      title: "Warning",
-      text: "Wait, please. Crowdsale company hasn't started yet. It'll start from <b>" + startBlock + "</b> block. Current block is <b>" + curBlock + "</b>.",
-      html: true,
-      type: "warning"
-    });
+  sweetAlert({
+    title: "Warning",
+    text: "Wait, please. Crowdsale company hasn't started yet. It'll start from <b>" + startBlock + "</b> block. Current block is <b>" + curBlock + "</b>.",
+    html: true,
+    type: "warning"
+  });
 }
 
 export function investmentDisabledAlertInTime(startTime) {
-    sweetAlert({
-      title: "Warning",
-      text: "Wait, please. Crowdsale company hasn't started yet. It'll start from <b>" + new Date(startTime) + "</b>.",
-      html: true,
-      type: "warning"
-    });
+  sweetAlert({
+    title: "Warning",
+    text: "Wait, please. Crowdsale company hasn't started yet. It'll start from <b>" + new Date(startTime) + "</b>.",
+    html: true,
+    type: "warning"
+  });
 }
 
 export function incorrectNetworkAlert(correctNetworkName, incorrectNetworkName) {
-    sweetAlert({
-      title: "Warning",
-      text: "Crowdsale contract is from <b>" + correctNetworkName + " network</b>. But you are connected to <b>" + incorrectNetworkName + " network</b>. Please, change connection in MetaMask/Oracles plugin.",
-      html: true,
-      type: "warning"
-    });
+  sweetAlert({
+    title: "Warning",
+    text: "Crowdsale contract is from <b>" + correctNetworkName + " network</b>. But you are connected to <b>" + incorrectNetworkName + " network</b>. Please, change connection in MetaMask/Oracles plugin.",
+    html: true,
+    type: "warning"
+  });
 }
 
 export function noDeploymentOnMainnetAlert() {
-    sweetAlert({
-      title: "Warning",
-      text: "Wizard is under maintenance on Ethereum Mainnet. Please come back later or use Kovan/Rinkeby/Oracles. Follow <a href='https://twitter.com/oraclesorg'>https://twitter.com/oraclesorg</a> for status.",
-      html: true,
-      type: "warning"
-    });
+  sweetAlert({
+    title: "Warning",
+    text: "Wizard is under maintenance on Ethereum Mainnet. Please come back later or use Kovan/Rinkeby/Oracles. Follow <a href='https://twitter.com/oraclesorg'>https://twitter.com/oraclesorg</a> for status.",
+    html: true,
+    type: "warning"
+  });
 }
 
 export function warningOnMainnetAlert(tiersCount, cb) {
   let n = 100 //fraction to round
-    let estimatedCost = 1.0 / n * Math.ceil(n * tiersCount * 0.16)
-    let estimatedTxsCount = tiersCount * 12
-    sweetAlert({
-      title: "Warning",
-      text: "You are about to sign " + estimatedTxsCount + " TXs. You will see an individual Metamask windows for each of it. Please don't open two or more instances of Wizard in one browser. ICO Wizard will create " + tiersCount + "-tier(s) crowdsale for you. The total cost will be around " + estimatedCost + " ETH. Are you sure you want to proceed?",
-      html: true,
-      type: "warning",
-      showCancelButton: true,
-      confirmButtonText: 'Yes, I am sure!',
-      cancelButtonText: "No, cancel it!",
-    },
-    function(isConfirm) {
-        if (isConfirm) {
-          cb();
-        }
-    });
+  let estimatedCost = 1.0 / n * Math.ceil(n * tiersCount * 0.16)
+  let estimatedTxsCount = tiersCount * 12
+  sweetAlert({
+    title: "Warning",
+    text: "You are about to sign " + estimatedTxsCount + " TXs. You will see an individual Metamask windows for each of it. Please don't open two or more instances of Wizard in one browser. ICO Wizard will create " + tiersCount + "-tier(s) crowdsale for you. The total cost will be around " + estimatedCost + " ETH. Are you sure you want to proceed?",
+    html: true,
+    type: "warning",
+    showCancelButton: true,
+    confirmButtonText: 'Yes, I am sure!',
+    cancelButtonText: "No, cancel it!",
+  },
+  function(isConfirm) {
+    if (isConfirm) {
+      cb();
+    }
+  });
 }

--- a/src/utils/blockchainHelpers.js
+++ b/src/utils/blockchainHelpers.js
@@ -3,14 +3,13 @@ import { incorrectNetworkAlert, noMetaMaskAlert, invalidNetworkIDAlert } from '.
 import { getEncodedABIClientSide } from './microservices'
 import { GAS_PRICE, CHAINS } from './constants'
 import { web3Store } from '../stores'
-import { toJSON, isObservable, toJS } from 'mobx'
 
 // instantiate new web3 instance
 const web3 = web3Store.web3
 
 // get current provider
 export function getCurrentProvider() {
-	console.log(web3.currentProvider);
+  console.log(web3.currentProvider);
   return web3.currentProvider;
 }
 
@@ -37,7 +36,7 @@ export function checkWeb3(web3) {
 
 export function getWeb3(cb) {
   var web3 = window.web3;
-	if (typeof web3 === 'undefined') {
+  if (typeof web3 === 'undefined') {
     // no web3, use fallback
     console.error("Please use a web3 browser");
     const devEnvironment = process.env.NODE_ENV === 'development';
@@ -75,27 +74,20 @@ export function checkNetWorkByID(web3, _networkIdFromGET) {
 
 export function getNetWorkNameById(_id) {
   switch (parseInt(_id, 10)) {
-    case 1: {
+    case 1:
       return CHAINS.MAINNET;
-    } break;
-    case 2: {
+    case 2:
       return CHAINS.MORDEN;
-    } break;
-    case 3: {
+    case 3:
       return CHAINS.ROPSTEN;
-    } break;
-    case 4: {
+    case 4:
       return CHAINS.RINKEBY;
-    } break;
-    case 42: {
+    case 42:
       return CHAINS.KOVAN;
-    } break;
-     case 12648430: {
-       return CHAINS.ORACLES;
-    }  break;
-    default: {
+    case 12648430:
+      return CHAINS.ORACLES;
+    default:
       return null;
-    } break;
   }
 }
 
@@ -110,28 +102,14 @@ export function setExistingContractParams(abi, addr, setContractProperty) {
   setTimeout(function() {
     getWeb3((web3) => {
       attachToContract(web3, abi, addr, function(err, crowdsaleContract) {
-        let propsCount = 0;
-        let cbCount = 0;
-        propsCount++;
         crowdsaleContract.token.call(function(err, tokenAddr) {
-          cbCount++;
           console.log("tokenAddr: " + tokenAddr);
-          // state.contracts.token.addr = tokenAddr;
           setContractProperty('token', 'addr', tokenAddr)
-          // if (propsCount === cbCount) {
-          //   $this.setState(state);
-          // }
         });
 
-        propsCount++;
         crowdsaleContract.multisigWallet.call(function(err, multisigWalletAddr) {
-          cbCount++;
           console.log("multisigWalletAddr: " + multisigWalletAddr);
-          // state.contracts.multisig.addr = multisigWalletAddr;
           setContractProperty('multisig', 'addr', multisigWalletAddr)
-          // if (propsCount === cbCount) {
-          //   $this.setState(state);
-          // }
         });
       });
     })

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -119,13 +119,13 @@ export const VALIDATION_TYPES = {
   EMPTY: 'EMPTY',
   INVALID: 'INVALID'
 }
-const { VALID, EMPTY, INVALID } = VALIDATION_TYPES
+const { VALID, EMPTY } = VALIDATION_TYPES
 
 export const intitialStepTwoValidations = {
   validations: {
-      name: EMPTY,
-      decimals: EMPTY,
-      ticker: EMPTY
+    name: EMPTY,
+    decimals: EMPTY,
+    ticker: EMPTY
   }
 }
 
@@ -143,22 +143,22 @@ export const initialStepTwoValues = {
 
 export const intitialStepThreeValidations = {
   validations: [{
-      tier: VALID,
-      startTime: VALID,
-      endTime: VALID,
-      walletAddress: EMPTY,
-      supply: VALID,
-      rate: EMPTY
+    tier: VALID,
+    startTime: VALID,
+    endTime: VALID,
+    walletAddress: EMPTY,
+    supply: VALID,
+    rate: EMPTY
   }]
 }
 
 export const initialStepThreeValues = {
   crowdsale: [{
-      tier: '',
-      startTime: '',
-      endTime: '',
-      walletAddress: '',
-      supply: ''
+    tier: '',
+    startTime: '',
+    endTime: '',
+    walletAddress: '',
+    supply: ''
   }]
 }
 
@@ -341,7 +341,7 @@ export const TOAST = {
     SUCCESS: 'warning'
   },
   MESSAGE: {
-		TRANSACTION_FAILED: 'Transaction has failed, please retry',
+    TRANSACTION_FAILED: 'Transaction has failed, please retry',
     CONTRACT_DOWNLOAD_FAILED: 'Contract Download failed',
     CONTRACT_DOWNLOAD_SUCCESS: 'A file with contracts and metadata downloaded on your computer'
   },

--- a/src/utils/copy.js
+++ b/src/utils/copy.js
@@ -1,18 +1,18 @@
 import Clipboard from 'clipboard';
 
 export function copy(cls) {
-    var clipboard = new Clipboard('.' + cls);
+  var clipboard = new Clipboard('.' + cls);
 
-    clipboard.on('success', function(e) {
-        console.info('Action:', e.action);
-        console.info('Text:', e.text);
-        console.info('Trigger:', e.trigger);
+  clipboard.on('success', function(e) {
+    console.info('Action:', e.action);
+    console.info('Text:', e.text);
+    console.info('Trigger:', e.trigger);
 
-        e.clearSelection();
-    });
+    e.clearSelection();
+  });
 
-    clipboard.on('error', function(e) {
-        console.error('Action:', e.action);
-        console.error('Trigger:', e.trigger);
-    });
+  clipboard.on('error', function(e) {
+    console.error('Action:', e.action);
+    console.error('Trigger:', e.trigger);
+  });
 }

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1,6 +1,6 @@
 import { VALIDATION_TYPES, TRUNC_TO_DECIMALS, TOAST } from './constants'
 import { contractStore, tokenStore, tierStore, web3Store } from '../stores'
-const { VALID, EMPTY, INVALID } = VALIDATION_TYPES
+const { VALID, INVALID } = VALIDATION_TYPES
 
 export function getQueryVariable(variable) {
   var query = window.location.search.substring(1);
@@ -19,7 +19,7 @@ export function getURLParam(key,target){
     target = window.location.href;
   }
 
-  key = key.replace(/[\[]/, "\\\[").replace(/[\]]/, "\\\]");
+  key = key.replace(/[[]/, "\\[").replace(/[\]]/, "\\]");
 
   var pattern = key + '=([^&#]+)';
   var o_reg = new RegExp(pattern,'ig');
@@ -36,7 +36,7 @@ export function getURLParam(key,target){
   if (!values.length) {
     return null;
   } else {
-    return values.length == 1 ? values[0] : values;
+    return values.length === 1 ? values[0] : values;
   }
 }
 
@@ -116,96 +116,97 @@ export const getconstructorParams = (abiConstructor, vals, crowdsaleNum) => {
       params.vals.push(vals[j]);
     } else {
       switch(inp.name) {
-        case "_startBlock": {
+        case "_startBlock":
           params.vals.push(tierStore.tiers[crowdsaleNum].startBlock);
-        } break;
-        case "_start": {
+          break;
+        case "_start":
           params.vals.push(toFixed(new Date(tierStore.tiers[crowdsaleNum].startTime).getTime()/1000).toString());
-        } break;
-        case "_endBlock": {
+          break;
+        case "_endBlock":
           params.vals.push(tierStore.tiers[crowdsaleNum].endBlock);
-        } break;
-        case "_end": {
+          break;
+        case "_end":
           params.vals.push(toFixed(new Date(tierStore.tiers[crowdsaleNum].endTime).getTime()/1000).toString());
-        } break;
-        case "_rate": {
+          break;
+        case "_rate":
           params.vals.push(tierStore.tiers[crowdsaleNum].rate);
-        } break;
+          break;
         case "_wallet":
-        case "_beneficiary": {
+        case "_beneficiary":
           params.vals.push(tierStore.tiers[crowdsaleNum].walletAddress);
-        } break;
-        case "_multisigWallet": {
+          break;
+        case "_multisigWallet":
           //params.vals.push(contractStore.multisig.addr);
           params.vals.push(tierStore.tiers[0].walletAddress);
-        } break;
-        case "_pricingStrategy": {
+          break;
+        case "_pricingStrategy":
           params.vals.push(contractStore.pricingStrategy.addr[crowdsaleNum]);
-        } break;
-        case "_token": {
+          break;
+        case "_token":
           params.vals.push(contractStore.token.addr);
-        } break;
-        case "_crowdsale": {
+          break;
+        case "_crowdsale":
           params.vals.push(contractStore.crowdsale.addr[crowdsaleNum]);
-        } break;
-        case "_crowdsaleSupply": {
+          break;
+        case "_crowdsaleSupply":
           params.vals.push(tierStore.tiers[crowdsaleNum].supply);
-        } break;
-        case "_name": {
+          break;
+        case "_name":
           params.vals.push(tokenStore.name);
-        } break;
-        case "_symbol": {
+          break;
+        case "_symbol":
           params.vals.push(tokenStore.ticker);
-        } break;
-        case "_decimals": {
+          break;
+        case "_decimals":
           params.vals.push(tokenStore.decimals);
-        } break;
-        case "_globalMinCap": {
+          break;
+        case "_globalMinCap":
           params.vals.push(tierStore.tiers[0].whitelistdisabled === "yes"?tokenStore.globalmincap?toFixed(tokenStore.globalmincap*10**tokenStore.decimals).toString():0:0);
-        } break;
+          break;
         case "_tokenSupply":
-        case "_initialSupply": {
+        case "_initialSupply":
           params.vals.push(tokenStore.supply);
-        } break;
-        case "_maximumSellableTokens": {
+          break;
+        case "_maximumSellableTokens":
           params.vals.push(toFixed(tierStore.tiers[crowdsaleNum].supply*10**tokenStore.decimals).toString());
-        } break;
-        case "_minimumFundingGoal": {
+          break;
+        case "_minimumFundingGoal":
           params.vals.push(0);
-        } break;
-        case "_mintable": {
+          break;
+        case "_mintable":
           params.vals.push(true);
-        } break;
-        case "_tranches": {
+          break;
+        case "_tranches":
           params.vals.push(tierStore.tiers[crowdsaleNum].tranches);
-        } break;
-        case "_secondsTimeLocked": {
+          break;
+        case "_secondsTimeLocked":
           params.vals.push(1)
-        } break;
-        case "_tokenTransferProxy": {
+          break;
+        case "_tokenTransferProxy":
           params.vals.push(contractStore.tokenTransferProxy.addr)
-        } break;
-        case "_required": {
+          break;
+        case "_required":
           params.vals.push(1)
-        } break;
-        case "_owners": {
+          break;
+        case "_owners":
           let owners = [];
           owners.push(tierStore.tiers[crowdsaleNum].walletAddress);
           params.vals.push(owners)
-        } break;
-        case "_oneTokenInWei": {
+          break;
+        case "_oneTokenInWei":
           let oneTokenInETHRaw = toFixed(1/tierStore.tiers[crowdsaleNum].rate).toString()
           let oneTokenInETH = floorToDecimals(TRUNC_TO_DECIMALS.DECIMALS18, oneTokenInETHRaw)
-          params.vals.push(web3Store.web3.utils.toWei(oneTokenInETH, "ether"));                } break;
-        case "_isUpdatable": {
-          params.vals.push(tierStore.tiers[crowdsaleNum].updatable?tierStore.tiers[crowdsaleNum].updatable=="on"?true:false:false);
-        } break;
-        case "_isWhiteListed": {
-          params.vals.push(tierStore.tiers[0].whitelistdisabled?tierStore.tiers[0].whitelistdisabled=="yes"?false:true:false);
-        } break;
-        default: {
+          params.vals.push(web3Store.web3.utils.toWei(oneTokenInETH, "ether"));
+          break;
+        case "_isUpdatable":
+          params.vals.push(tierStore.tiers[crowdsaleNum].updatable?tierStore.tiers[crowdsaleNum].updatable==="on"?true:false:false);
+          break;
+        case "_isWhiteListed":
+          params.vals.push(tierStore.tiers[0].whitelistdisabled?tierStore.tiers[0].whitelistdisabled==="yes"?false:true:false);
+          break;
+        default:
           params.vals.push("");
-        } break;
+          break;
       }
     }
   }
@@ -238,13 +239,15 @@ if (!Math.floor10) {
 
 const getTimeAsNumber = (time) => new Date(time).getTime()
 
-export const getOldState = (props, defaultState) => props && props.location && props.location.query && props.location.query.state || defaultState
+export const getOldState = (props, defaultState) => (props && props.location && props.location.query && props.location.query.state) || defaultState
 
 export const getStepClass = (step, activeStep) => step === activeStep ? "step-navigation step-navigation_active" : "step-navigation"
 
 export const stepsAreValid = (steps) => {
   let newSteps = Object.assign({}, steps)
-  newSteps[0] !== undefined ? delete newSteps[0] : ''
+  if (newSteps[0] !== undefined) {
+    delete newSteps[0]
+  }
   return Object.values(newSteps).length > 3 && Object.values(newSteps).every(step => step === VALID)
 }
 
@@ -285,8 +288,6 @@ const inputFieldValidators = {
   rate: validateRate
 }
 
-const inputFieldIsUnsubmitted = (currentValidation, newValidation) => currentValidation === EMPTY
-
 const isNotWhiteListTierObject = (value) => !(typeof value === 'object' && value.hasOwnProperty('whitelist') === true && value.hasOwnProperty('tier') === true)
 
 // still thinks that we do not have an array... we do
@@ -317,7 +318,7 @@ export const allFieldsAreValid = (parent, state) => {
   if( Object.prototype.toString.call( newState[parent] ) === '[object Array]' ) {
     if (newState[parent].length > 0) {
       for (let i = 0; i < newState[parent].length; i++) {
-        Object.keys(newState[parent][i]).map(property => {
+        Object.keys(newState[parent][i]).forEach(property => { // eslint-disable-line no-loop-func
           values.push(newState[parent][i][property])
           properties.push(property);
         })
@@ -340,7 +341,7 @@ export const allFieldsAreValid = (parent, state) => {
       value = newState[parent][property]
     }
     iterator++
-    if (parent == "token" && property == "supply") return VALID
+    if (parent === "token" && property === "supply") return VALID
     return validateValue(value, property)
   })
 
@@ -349,13 +350,13 @@ export const allFieldsAreValid = (parent, state) => {
 
 export function toFixed(x) {
   if (Math.abs(x) < 1.0) {
-    var e = parseInt(x.toString().split('e-')[1]);
+    let e = parseInt(x.toString().split('e-')[1], 10);
     if (e) {
       x *= Math.pow(10,e-1);
       x = '0.' + (new Array(e)).join('0') + x.toString().substring(2);
     }
   } else {
-    var e = parseInt(x.toString().split('+')[1]);
+    let e = parseInt(x.toString().split('+')[1], 10);
     if (e > 20) {
       e -= 20;
       x /= Math.pow(10,e);


### PR DESCRIPTION
This PR adds a npm script for linting and fixes all linter errors and warnings (except three that were too cumbersome to fix; I added inline comments to ignore those).

Most of the work is whitespace fixes, so it's a good idea to use the "No whitespace" option in the github diff.

I also added a `.editorconfig` file to set the basic code style (2 spaces indentation, Unix-style newlines, etc.)