### PR TITLE
(Refactor) Switch from SweetAlert to SweetAlert2

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "solc": "^0.4.14",
     "style-loader": "0.18.2",
     "sw-precache-webpack-plugin": "0.11.3",
-    "sweetalert": "^1.1.3",
+    "sweetalert2": "^7.0.9",
     "url-loader": "0.5.9",
     "webpack": "^2.6.1",
     "webpack-dev-server": "2.5.0",

--- a/src/utils/alerts.js
+++ b/src/utils/alerts.js
@@ -1,94 +1,83 @@
-import sweetAlert from 'sweetalert';
-import 'sweetalert/dist/sweetalert.css';
+import sweetAlert2 from 'sweetalert2';
 
 export function noMetaMaskAlert() {
-  sweetAlert({
+  sweetAlert2({
     title: "Warning",
-    text: "You don't have Metamask installed. Check ICO Wizard GitHub for <a href='https://github.com/oraclesorg/ico-wizard' target='blank'>the instruction</a>.",
-    html: true,
+    html: "You don't have Metamask installed. Check ICO Wizard GitHub for <a href='https://github.com/oraclesorg/ico-wizard' target='blank'>the instruction</a>.",
     type: "warning"
   });
 }
 
 export function noContractDataAlert() {
-  sweetAlert({
+  sweetAlert2({
     title: "Warning",
-    text: "The crowdsale data is empty. There is nothing to deploy. Please, start ICO Wizard from the beginning.",
-    html: true,
+    html: "The crowdsale data is empty. There is nothing to deploy. Please, start ICO Wizard from the beginning.",
     type: "warning"
   });
 }
 
 export function noContractAlert() {
-  sweetAlert({
+  sweetAlert2({
     title: "Warning",
-    text: "There is no contract at this address",
-    html: true,
+    html: "There is no contract at this address",
     type: "warning"
   });
 }
 
 export function invalidCrowdsaleAddrAlert() {
-  sweetAlert({
+  sweetAlert2({
     title: "Warning",
-    text: "Invalid crowdsale address is indicated in config and/or in query string.",
-    html: true,
+    html: "Invalid crowdsale address is indicated in config and/or in query string.",
     type: "warning"
   });
 }
 
 export function invalidNetworkIDAlert() {
-  sweetAlert({
+  sweetAlert2({
     title: "Warning",
-    text: "Invalid network ID is indicated in config and/or in query string.",
-    html: true,
+    html: "Invalid network ID is indicated in config and/or in query string.",
     type: "warning"
   });
 }
 
 export function successfulInvestmentAlert(tokensToInvest) {
-  sweetAlert({
+  sweetAlert2({
     title: "Success",
-    text: "Congrats! You've successfully bought " + tokensToInvest + " tokens!",
-    html: true,
+    html: "Congrats! You've successfully bought " + tokensToInvest + " tokens!",
     type: "success"
-  }, function() {
-    window.location.reload();
+  }).then(function(result) {
+    result.value && window.location.reload();
   });
 }
 
 export function investmentDisabledAlert(startBlock, curBlock) {
-  sweetAlert({
+  sweetAlert2({
     title: "Warning",
-    text: "Wait, please. Crowdsale company hasn't started yet. It'll start from <b>" + startBlock + "</b> block. Current block is <b>" + curBlock + "</b>.",
-    html: true,
+    html: "Wait, please. Crowdsale company hasn't started yet. It'll start from <b>" + startBlock + "</b> block. Current block is <b>" + curBlock + "</b>.",
     type: "warning"
   });
 }
 
 export function investmentDisabledAlertInTime(startTime) {
-  sweetAlert({
+  sweetAlert2({
     title: "Warning",
-    text: "Wait, please. Crowdsale company hasn't started yet. It'll start from <b>" + new Date(startTime) + "</b>.",
-    html: true,
+    html: "Wait, please. Crowdsale company hasn't started yet. It'll start from <b>" + new Date(startTime) + "</b>.",
     type: "warning"
   });
 }
 
 export function incorrectNetworkAlert(correctNetworkName, incorrectNetworkName) {
-  sweetAlert({
+  sweetAlert2({
     title: "Warning",
-    text: "Crowdsale contract is from <b>" + correctNetworkName + " network</b>. But you are connected to <b>" + incorrectNetworkName + " network</b>. Please, change connection in MetaMask/Oracles plugin.",
-    html: true,
+    html: "Crowdsale contract is from <b>" + correctNetworkName + " network</b>. But you are connected to <b>" + incorrectNetworkName + " network</b>. Please, change connection in MetaMask/Oracles plugin.",
     type: "warning"
   });
 }
 
 export function noDeploymentOnMainnetAlert() {
-  sweetAlert({
+  sweetAlert2({
     title: "Warning",
-    text: "Wizard is under maintenance on Ethereum Mainnet. Please come back later or use Kovan/Rinkeby/Oracles. Follow <a href='https://twitter.com/oraclesorg'>https://twitter.com/oraclesorg</a> for status.",
-    html: true,
+    html: "Wizard is under maintenance on Ethereum Mainnet. Please come back later or use Kovan/Rinkeby/Oracles. Follow <a href='https://twitter.com/oraclesorg'>https://twitter.com/oraclesorg</a> for status.",
     type: "warning"
   });
 }
@@ -97,18 +86,14 @@ export function warningOnMainnetAlert(tiersCount, cb) {
   let n = 100 //fraction to round
   let estimatedCost = 1.0 / n * Math.ceil(n * tiersCount * 0.16)
   let estimatedTxsCount = tiersCount * 12
-  sweetAlert({
+  sweetAlert2({
     title: "Warning",
-    text: "You are about to sign " + estimatedTxsCount + " TXs. You will see an individual Metamask windows for each of it. Please don't open two or more instances of Wizard in one browser. ICO Wizard will create " + tiersCount + "-tier(s) crowdsale for you. The total cost will be around " + estimatedCost + " ETH. Are you sure you want to proceed?",
-    html: true,
+    html: "You are about to sign " + estimatedTxsCount + " TXs. You will see an individual Metamask windows for each of it. Please don't open two or more instances of Wizard in one browser. ICO Wizard will create " + tiersCount + "-tier(s) crowdsale for you. The total cost will be around " + estimatedCost + " ETH. Are you sure you want to proceed?",
     type: "warning",
     showCancelButton: true,
     confirmButtonText: 'Yes, I am sure!',
     cancelButtonText: "No, cancel it!",
-  },
-  function(isConfirm) {
-    if (isConfirm) {
-      cb();
-    }
+  }).then(function(result) {
+    result.value && cb();
   });
 }

--- a/src/utils/alerts.js
+++ b/src/utils/alerts.js
@@ -94,6 +94,8 @@ export function warningOnMainnetAlert(tiersCount, cb) {
     confirmButtonText: 'Yes, I am sure!',
     cancelButtonText: "No, cancel it!",
   }).then(function(result) {
-    result.value && cb();
+    if (result.value) {
+      cb()
+    }
   });
 }

--- a/src/utils/alerts.js
+++ b/src/utils/alerts.js
@@ -46,7 +46,9 @@ export function successfulInvestmentAlert(tokensToInvest) {
     html: "Congrats! You've successfully bought " + tokensToInvest + " tokens!",
     type: "success"
   }).then(function(result) {
-    result.value && window.location.reload();
+    if (result.value) {
+      window.location.reload();
+    }
   });
 }
 


### PR DESCRIPTION
I would like to propose to switch from SweetAlert to [SweetAlert2](https://github.com/limonte/sweetalert2) - the supported fork of SweetAlert. The original reason for creating SweetAlert2 is the inactivity of SweetAlert: https://stackoverflow.com/a/27842854/1331425 

### Reasons to switch:

1. Accessibility (WAI-ARIA) - SweetAlert2 is fully WAI-ARIA compatible and supports all popular screen-readers. Accessibility is a must in 2017, there are a lot of explanatory and tech articles, but this one is truly inspirable: [Software development 450 words per minute](https://www.vincit.fi/en/blog/software-development-450-words-per-minute/)

2. Better buttons contrast is a huge advantage for all users especially for users with vision disabilities. 

3. Better support, average time to resolve an issue:

   - SweetAlert: ![](http://isitmaintained.com/badge/resolution/t4t5/sweetalert.svg)
   - SweetAlert2: ![](http://isitmaintained.com/badge/resolution/limonte/sweetalert2.svg)

4. SweetAlert2 is more popular that SweetAlert:

   - SweetAlert: ![](https://img.shields.io/npm/dm/sweetalert.svg)
   - SweetAlert2: ![](https://img.shields.io/npm/dm/sweetalert2.svg)
